### PR TITLE
refactor: refactor repetitive code and clean docs

### DIFF
--- a/cmd/odf/ceph/purge_osd.go
+++ b/cmd/odf/ceph/purge_osd.go
@@ -23,11 +23,10 @@ var cephPurgeOsdCmd = &cobra.Command{
 	PreRunE: validateOsdID,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		clientsets := root.GetClientsets(ctx)
 		forceflagValue := "false"
 		osdID := args[0]
 
-		safeToDestroy, err := osd.SafeToDestroy(ctx, clientsets, root.OperatorNamespace, root.StorageClusterNamespace, osdID)
+		safeToDestroy, err := osd.SafeToDestroy(ctx, root.ClientSets, root.OperatorNamespace, root.StorageClusterNamespace, osdID)
 		if !safeToDestroy {
 			var answer string
 			yesForceDestroyOSD := "yes-force-destroy-osd"
@@ -44,7 +43,7 @@ var cephPurgeOsdCmd = &cobra.Command{
 			logging.Fatal(errors.Wrapf(err, "failed to check if osd.%s is safe to destroy", osdID))
 		}
 
-		rook.PurgeOsd(ctx, clientsets, root.OperatorNamespace, root.StorageClusterNamespace, osdID, forceflagValue)
+		rook.PurgeOsd(ctx, root.ClientSets, root.OperatorNamespace, root.StorageClusterNamespace, osdID, forceflagValue)
 	},
 }
 

--- a/cmd/odf/get/get_recovery_profile.go
+++ b/cmd/odf/get/get_recovery_profile.go
@@ -13,7 +13,6 @@ var getRecoveryProfile = &cobra.Command{
 	DisableFlagParsing: true,
 	Args:               cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := root.GetClientsets(cmd.Context())
-		osd.GetProfile(cmd.Context(), clientsets, root.OperatorNamespace, root.StorageClusterNamespace)
+		osd.GetProfile(cmd.Context(), root.ClientSets, root.OperatorNamespace, root.StorageClusterNamespace)
 	},
 }

--- a/cmd/odf/root/root.go
+++ b/cmd/odf/root/root.go
@@ -18,6 +18,7 @@ var (
 	KubeContext             string
 	OperatorNamespace       string
 	StorageClusterNamespace string
+	ClientSets              *k8sutil.Clientsets
 )
 
 // RootCmd represents the odf command
@@ -29,6 +30,7 @@ var RootCmd = &cobra.Command{
 		if StorageClusterNamespace != "" && OperatorNamespace == "" {
 			OperatorNamespace = StorageClusterNamespace
 		}
+		ClientSets = getClientsets(cmd.Context())
 	},
 }
 
@@ -48,7 +50,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&KubeContext, "context", "", "Openshift context to use")
 }
 
-func GetClientsets(ctx context.Context) *k8sutil.Clientsets {
+func getClientsets(ctx context.Context) *k8sutil.Clientsets {
 	var err error
 
 	clientsets := &k8sutil.Clientsets{}

--- a/cmd/odf/set/log_level.go
+++ b/cmd/odf/set/log_level.go
@@ -14,7 +14,6 @@ var setCephLogLevelCmd = &cobra.Command{
 	Args:               cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		clientsets := root.GetClientsets(ctx)
-		rook.SetCephLogLevel(ctx, clientsets, root.OperatorNamespace, root.StorageClusterNamespace, args[0], args[1], args[2])
+		rook.SetCephLogLevel(ctx, root.ClientSets, root.OperatorNamespace, root.StorageClusterNamespace, args[0], args[1], args[2])
 	},
 }

--- a/cmd/odf/set/set_recovery_profile.go
+++ b/cmd/odf/set/set_recovery_profile.go
@@ -14,7 +14,6 @@ var setRecoveryProfile = &cobra.Command{
 	ValidArgs:          []string{"high_client_ops", "high_recovery_ops", "balanced"},
 	Args:               cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
-		clientsets := root.GetClientsets(cmd.Context())
-		osd.SetProfile(cmd.Context(), clientsets, args[0], root.OperatorNamespace, root.StorageClusterNamespace)
+		osd.SetProfile(cmd.Context(), root.ClientSets, args[0], root.OperatorNamespace, root.StorageClusterNamespace)
 	},
 }

--- a/cmd/odf/subvolume/subvolume.go
+++ b/cmd/odf/subvolume/subvolume.go
@@ -1,16 +1,3 @@
-/*
-Copyright 2023 The Rook Authors. All rights reserved.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-	http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package subvolume
 
 import (
@@ -30,9 +17,8 @@ var listCmd = &cobra.Command{
 	Short: "Print the list of stale subvolumes no longer in use.",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		clientsets := root.GetClientsets(ctx)
 		staleSubvol, _ := cmd.Flags().GetBool("stale")
-		subvolume.List(ctx, clientsets, root.OperatorNamespace, root.StorageClusterNamespace, staleSubvol)
+		subvolume.List(ctx, root.ClientSets, root.OperatorNamespace, root.StorageClusterNamespace, staleSubvol)
 	},
 }
 
@@ -43,11 +29,10 @@ var deleteCmd = &cobra.Command{
 	Args:               cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		clientsets := root.GetClientsets(ctx)
 		subList := args[0]
 		fs := args[1]
 		svg := args[2]
-		subvolume.Delete(ctx, clientsets, root.OperatorNamespace, root.StorageClusterNamespace, subList, fs, svg)
+		subvolume.Delete(ctx, root.ClientSets, root.OperatorNamespace, root.StorageClusterNamespace, subList, fs, svg)
 	},
 }
 

--- a/docs/set.md
+++ b/docs/set.md
@@ -2,9 +2,8 @@
 
 The set command supports the following sub-commands:
 
-- [Set](#set)
-  - [recovery-profile](#recovery-profile)
-  - [ceph-log-level](#ceph-log-level)
+* [recovery-profile](#recovery-profile)
+* [ceph-log-level](#ceph-log-level)
 
 ## recovery-profile
 
@@ -23,13 +22,11 @@ To verify the recovery profile setting run [odf get recovery-profile](get.md#rec
 
 ## ceph-log-level
 
-This command will set the log level for different ceph [subsystems](https://docs.ceph.com/en/latest/rados/troubleshooting/log-and-debug/#ceph-subsystems). 
+This command will set the log level for different ceph [subsystems](https://docs.ceph.com/en/latest/rados/troubleshooting/log-and-debug/#ceph-subsystems).
 The `debug_` prefix will be automatically added to the subsystem when enabling the logging.
-
 
 ``` bash
 odf set ceph-log-level osd crush 20
 ```
 
 Once the logging efforts are complete, restore the systems to their default or to a level suitable for normal operations.
-

--- a/docs/subvolume.md
+++ b/docs/subvolume.md
@@ -7,12 +7,14 @@ This would consider all the cases where we can have stale subvolume
 and delete them without impacting other resources and attached volumes.
 
 The subvolume command supports the following sub commands:
-* `ls` : [ls](#ls) 
-* `delete`: [delete](#delete) 
-* 
+
+* [ls](#ls)
+* [delete](#delete)
+
 ## ls
 
 This command will lists all the subvolumes. It also accepts the stale flag to check for stale subvolumes.
+
 * `--stale`: lists only stale subvolumes
 
 ```bash
@@ -38,7 +40,8 @@ odf subvolume ls --stale
 This command deletes stale subvolumes after user's confirmation.
 `delete <subvolumes> <filesystem> <subvolumegroup>`:
 It will delete only the stale subvolumes to prevent any loss of data.
-  * subvolumes: comma-separated list of subvolumes of same filesystem and subvolumegroup.
+
+* subvolumes: comma-separated list of subvolumes of same filesystem and subvolumegroup.
 
 ```bash
 odf subvolume delete csi-vol-427774b4-340b-11ed-8d66-0242ac110004 ocs-storagecluster csi


### PR DESCRIPTION
Refactoring Go code to use cobra PreRun,PreRunE, PersistentPreRun, and PersistentPreRun feature to do pre-validation checks. Also, cleaning the docs using Markdown syntax in VsCode.

Signed-off-by: subhamkrai <srai@redhat.com>