### PR TITLE
Bug 2258744: cmd: add ceph subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The ODF CLI tool provides configuration and troubleshooting commands for OpenShi
 
 - `odf set recovery-profile <profile>`: Set the recovery profile to favor new IO, recovery, or balanced mode with options `high_client_ops`, `high_recovery_ops`, or `balanced`. The default is `balanced`.
 - `odf get recovery-profile`: Get the recovery profile value.
-- `odf set ceph-log-level <daemon> <subsystem> <log-level>`: Set the log level for Ceph daemons like OSD, mon, mds etc.
+- `odf set ceph log-level <daemon> <subsystem> <log-level>`: Set the log level for Ceph daemons like OSD, mon, mds etc.
   More information about the ceph subsystems can be found [here](https://docs.ceph.com/en/latest/rados/troubleshooting/log-and-debug/#ceph-subsystems)
 - `odf purge-osd <ID>`: Permanently remove an OSD from the cluster.
 - `odf help` : Display help text

--- a/cmd/odf/set/ceph.go
+++ b/cmd/odf/set/ceph.go
@@ -1,0 +1,14 @@
+package set
+
+import "github.com/spf13/cobra"
+
+var cephCmd = &cobra.Command{
+	Use:                "ceph",
+	Short:              "Configure ceph components",
+	DisableFlagParsing: true,
+	Args:               cobra.MinimumNArgs(1),
+}
+
+func init() {
+	cephCmd.AddCommand(setCephLogLevelCmd)
+}

--- a/cmd/odf/set/log_level.go
+++ b/cmd/odf/set/log_level.go
@@ -7,7 +7,7 @@ import (
 )
 
 var setCephLogLevelCmd = &cobra.Command{
-	Use:                "ceph-log-level",
+	Use:                "log-level",
 	Short:              "Set different log levels for ceph components like mon, osd and mds",
 	Example:            "odf set ceph-log-level osd crush 10",
 	DisableFlagParsing: true,

--- a/cmd/odf/set/set.go
+++ b/cmd/odf/set/set.go
@@ -13,5 +13,5 @@ var SetCmd = &cobra.Command{
 
 func init() {
 	SetCmd.AddCommand(setRecoveryProfile)
-	SetCmd.AddCommand(setCephLogLevelCmd)
+	SetCmd.AddCommand(cephCmd)
 }

--- a/docs/set.md
+++ b/docs/set.md
@@ -2,8 +2,10 @@
 
 The set command supports the following sub-commands:
 
-* [recovery-profile](#recovery-profile)
-* [ceph-log-level](#ceph-log-level)
+- [Set](#set)
+  - [recovery-profile](#recovery-profile)
+  - [ceph](#ceph)
+    - [log-level](#log-level)
 
 ## recovery-profile
 
@@ -20,13 +22,16 @@ odf set recovery-profile high_client_ops
 
 To verify the recovery profile setting run [odf get recovery-profile](get.md#recovery-profile).
 
-## ceph-log-level
+## ceph
+The `ceph` command helps update the Ceph configuration.
+
+### log-level
 
 This command will set the log level for different ceph [subsystems](https://docs.ceph.com/en/latest/rados/troubleshooting/log-and-debug/#ceph-subsystems).
 The `debug_` prefix will be automatically added to the subsystem when enabling the logging.
 
 ``` bash
-odf set ceph-log-level osd crush 20
+odf set ceph log-level osd crush 20
 ```
 
 Once the logging efforts are complete, restore the systems to their default or to a level suitable for normal operations.


### PR DESCRIPTION
Add a new ceph subcommand to change `odf set ceph-log-level <args>` to `odf set ceph log-level <args>`

Signed-off-by: sp98 <sapillai@redhat.com>
(cherry picked from commit 147c468510a851b2a6d52754db0019021d54c079)