### PR TITLE
mons: add command to restore mon quorum

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The ODF CLI tool provides configuration and troubleshooting commands for OpenShi
 - `odf help` : Display help text
 - `odf subvolume ls`: Display all the subvolumes
 - `odf subvolume delete <subvolume> <filesystem> <subvolumegroup>`: Deletes the stale subvolumes
+- `odf mons`
+  - `restore-quorum <monID>`: Restore the mon quorum based on a single healthy mon since quorum was lost with the other mons
 
 ## Documentation
 
@@ -20,6 +22,7 @@ Visit docs below for complete details about each command and their flags uses.
 - [set](docs/set.md)
 - [get](docs/get.md)
 - [purge-osd](docs/purge_osd.md)
+- [mon](docs/mons.md)
 
 ### Root args
 

--- a/cmd/odf/main.go
+++ b/cmd/odf/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/red-hat-storage/odf-cli/cmd/odf/get"
+	"github.com/red-hat-storage/odf-cli/cmd/odf/mon"
 	"github.com/red-hat-storage/odf-cli/cmd/odf/purgeosd"
 	"github.com/red-hat-storage/odf-cli/cmd/odf/root"
 	"github.com/red-hat-storage/odf-cli/cmd/odf/set"
@@ -23,5 +24,6 @@ func addcommands() {
 		get.GetCmd,
 		purgeosd.CephPurgeOsdCmd,
 		subvolume.SubvolumeCmd,
+		mon.MonsCmd,
 	)
 }

--- a/cmd/odf/mon/mon.go
+++ b/cmd/odf/mon/mon.go
@@ -1,0 +1,18 @@
+package mon
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// MonsCmd represents the mon command
+var MonsCmd = &cobra.Command{
+	Use:                "mons",
+	Short:              "Supports sub-commands for 'mons'",
+	DisableFlagParsing: true,
+	Hidden:             true,
+	Args:               cobra.ExactArgs(1),
+}
+
+func init() {
+	MonsCmd.AddCommand(RestoreQuorum)
+}

--- a/cmd/odf/mon/restore_quorum.go
+++ b/cmd/odf/mon/restore_quorum.go
@@ -1,0 +1,19 @@
+package mon
+
+import (
+	"github.com/red-hat-storage/odf-cli/cmd/odf/root"
+	"github.com/rook/kubectl-rook-ceph/pkg/mons"
+	"github.com/spf13/cobra"
+)
+
+// RestoreQuorum represents the mons command
+var RestoreQuorum = &cobra.Command{
+	Use:                "restore-quorum",
+	Short:              "When quorum is lost, restore quorum to the remaining healthy mon",
+	DisableFlagParsing: true,
+	Args:               cobra.ExactArgs(1),
+	Example:            "odf mons restore-quorum <mon_id>",
+	Run: func(cmd *cobra.Command, args []string) {
+		mons.RestoreQuorum(cmd.Context(), root.ClientSets, root.OperatorNamespace, root.StorageClusterNamespace, args[0])
+	},
+}

--- a/docs/mons.md
+++ b/docs/mons.md
@@ -1,0 +1,132 @@
+# Mon Commands
+
+## Restore Quorum
+
+Mon quorum is critical to the Ceph cluster. If majority of mons are not in quorum,
+the cluster will be down. If the majority of mons are also lost permanently,
+the quorum will need to be restore to a remaining good mon in order to bring
+the Ceph cluster up again.
+
+To restore the quorum in this disaster scenario:
+
+1. Identify that mon quorum is lost. Some indications include:
+   - The Rook operator log shows timeout errors and continuously fails to reconcile
+   - All commands in the toolbox are unresponsive
+   - Multiple mon pods are likely down
+2. Identify which mon has good state.
+   - Exec to a mon pod and run the following command
+     - `ceph daemon mon.<name> mon_status`
+     - For example, if connecting to mon.a, run: `ceph daemon mon.a mon_status`
+   - If multiple mons respond, find the mon with the highest `election_epoch`
+3. Start the toolbox pod if not already running
+4. Run the command below to restore quorum to that good mon
+5. Follow the prompts to confirm that you want to continue with each critical step of the restore
+6. The final prompt will be to restart the operator, which will add new mons to restore the full quorum size
+
+In this example, quorum is restored to mon **c**.
+
+```bash
+odf mons restore-quorum c
+```
+
+Before the restore proceeds, you will be prompted if you want to continue.
+For example, here is the output in a test cluster up to the point of starting the restore.
+
+```bash
+$ odf mons restore-quorum c
+mon=b, endpoint=192.168.64.168:6789
+mon=c, endpoint=192.168.64.167:6789
+mon=a, endpoint=192.168.64.169:6789
+Info: Check for the running toolbox
+Info: Waiting for the pod from deployment "rook-ceph-tools" to be running
+deployment.apps/rook-ceph-tools condition met
+
+Warning: Restoring mon quorum to mon c (192.168.64.167)
+Info: The mons to discard are: b a
+Info: Are you sure you want to restore the quorum to mon "c"? If so, enter: yes-really-restore
+```
+
+After entering `yes-really-restore`, the restore continues with output as such:
+
+```bash
+Info: proceeding
+deployment.apps/rook-ceph-operator scaled
+deployment.apps/rook-ceph-mon-a scaled
+deployment.apps/rook-ceph-mon-b scaled
+deployment.apps/rook-ceph-mon-c scaled
+Info: Waiting for operator and mon pods to stop
+pod/rook-ceph-operator-b5c96c99b-ggfg5 condition met
+pod/rook-ceph-mon-a-6cd67d89b4-5qhgj condition met
+pod/rook-ceph-mon-b-7d78cfd5-drztj condition met
+pod/rook-ceph-mon-c-56499b77d7-sbmfb condition met
+setting debug mode for "rook-ceph-mon-c"
+Info: setting debug command to main container
+Info: get pod for deployment rook-ceph-mon-c
+deployment.apps/rook-ceph-mon-c-debug created
+Info: ensure the debug deployment rook-ceph-mon-c is scaled up
+deployment.apps/rook-ceph-mon-c-debug scaled
+Info: Waiting for the pod from deployment "rook-ceph-mon-c-debug" to be running
+deployment.apps/rook-ceph-mon-c-debug condition met
+Info: Started debug pod, restoring the mon quorum in the debug pod
+Info: Extracting the monmap
+
+# Lengthy rocksdb output removed
+
+Info: Printing final monmap
+monmaptool: monmap file /tmp/monmap
+epoch 3
+fsid 818e8153-f17f-4ae3-b21f-078a4069affa
+last_changed 2022-10-19T22:04:46.097595+0000
+created 2022-10-19T22:01:11.347220+0000
+min_mon_release 17 (quincy)
+election_strategy: 1
+0: [v2:192.168.64.167:3300/0,v1:192.168.64.167:6789/0] mon.c
+Info: Restoring the mons in the rook-ceph-mon-endpoints configmap to the good mon
+configmap/rook-ceph-mon-endpoints patched
+Info: Stopping the debug pod for mon c
+setting debug mode for "rook-ceph-mon-c-debug"
+Info: removing debug mode from "rook-ceph-mon-c-debug"
+deployment.apps "rook-ceph-mon-c-debug" deleted
+deployment.apps/rook-ceph-mon-c scaled
+Info: Check that the restored mon is responding
+timed out
+command terminated with exit code 1
+Info: 0: waiting for ceph status to confirm single mon quorum
+Info: sleeping 5
+timed out
+command terminated with exit code 1
+Info: 1: waiting for ceph status to confirm single mon quorum
+Info: sleeping 5
+timed out
+command terminated with exit code 1
+Info: 2: waiting for ceph status to confirm single mon quorum
+Info: sleeping 5
+timed out
+command terminated with exit code 1
+Info: 3: waiting for ceph status to confirm single mon quorum
+Info: sleeping 5
+
+Info: finished waiting for ceph status
+Info: Purging the bad mons: b a
+Info: purging old mon: b
+deployment.apps "rook-ceph-mon-b" deleted
+Error from server (NotFound): services "rook-ceph-mon-b" not found
+Info: purging mon pvc if exists
+Error from server (NotFound): persistentvolumeclaims "rook-ceph-mon-b" not found
+Info: purging old mon: a
+deployment.apps "rook-ceph-mon-a" deleted
+Error from server (NotFound): services "rook-ceph-mon-a" not found
+Info: purging mon pvc if exists
+Error from server (NotFound): persistentvolumeclaims "rook-ceph-mon-a" not found
+Info: Mon quorum was successfully restored to mon c
+Info: Only a single mon is currently running
+Info: Press Enter to start the operator and expand to full mon quorum again
+```
+
+After reviewing that the cluster is healthy with a single mon, press Enter to continue:
+
+```bash
+Info: continuing
+deployment.apps/rook-ceph-operator scaled
+Info: The operator will now expand to full mon quorum
+```


### PR DESCRIPTION
This commits add `mons restore-quorum` command
to restore mon quorum based on single good mon.
Also adding docs for the commnad.