### PR TITLE
get: add get sub-command dr-health

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The ODF CLI tool provides configuration and troubleshooting commands for OpenShi
 - `odf get`:
   - `recovery-profile`: Get the recovery profile value.
   - `health`: Check health of the cluster and common configuration issues.
+  - `dr-health [ceph status args]`: Print the ceph status of a peer cluster in a mirroring-enabled environment thereby validating connectivity between ceph clusters. Ceph status args can be optionally passed, such as to change the log level: --debug-ms 1.
 - `odf purge-osd <ID>`: Permanently remove an OSD from the cluster.
 - `odf maintenance`: [Perform maintenance operations](docs/maintenance.md) on mons or OSDs. The mon or OSD deployment will be scaled down and replaced temporarily by a maintenance deployment.
   - `start <deployment-name>`

--- a/cmd/odf/get/dr_health.go
+++ b/cmd/odf/get/dr_health.go
@@ -1,0 +1,18 @@
+package get
+
+import (
+	"github.com/red-hat-storage/odf-cli/cmd/odf/root"
+	"github.com/rook/kubectl-rook-ceph/pkg/dr"
+	"github.com/spf13/cobra"
+)
+
+var drHealthCmd = &cobra.Command{
+	Use:                "dr-health",
+	Short:              "Print the ceph status of a peer cluster in a mirroring-enabled cluster.",
+	DisableFlagParsing: true,
+	Args:               cobra.MaximumNArgs(2),
+	Example:            "odf get dr-health [ceph status args]",
+	Run: func(cmd *cobra.Command, args []string) {
+		dr.Health(cmd.Context(), root.ClientSets, root.OperatorNamespace, root.StorageClusterNamespace, args)
+	},
+}

--- a/cmd/odf/get/get.go
+++ b/cmd/odf/get/get.go
@@ -16,4 +16,5 @@ func init() {
 	GetCmd.AddCommand(getRecoveryProfile)
 	GetCmd.AddCommand(rookCmd)
 	GetCmd.AddCommand(clusterHealth)
+	GetCmd.AddCommand(drHealthCmd)
 }

--- a/docs/get.md
+++ b/docs/get.md
@@ -4,6 +4,7 @@ The get command supports the following sub-commands:
 
 * [recovery-profile](#recovery-profile)
 * [health](#health)
+* [dr-health](#dr-health)
 
 ## recovery-profile
 
@@ -87,4 +88,46 @@ Info:   PgState: active+clean, PgCount: 113
 
 Info: Checking if at least one mgr pod is running
 rook-ceph-mgr-a-54f7dbddcd-h7j7m        Running openshift-storage       ip-10-0-64-239.us-west-1.compute.internal
+```
+
+## dr-health
+
+The DR health command is used to get the connection status of one cluster from another cluster in mirroring-enabled clusters. The cephblockpool is queried with mirroring-enabled and If not found will exit with relevant logs. Optionally, args can be passed to be appended to ceph status, for example: --debug-ms 1.
+
+```bash
+$ odf get dr-health
+
+Info: fetching the cephblockpools with mirroring enabled
+Info: found "ocs-storagecluster-cephblockpool" cephblockpool with mirroring enabled
+Info: running ceph status from peer cluster
+Info:   cluster:
+    id:     9a2e7e55-40e1-4a79-9bfa-c3e4750c6b0f
+    health: HEALTH_OK
+
+  services:
+    mon:        3 daemons, quorum a,b,c (age 2w)
+    mgr:        a(active, since 2w), standbys: b
+    mds:        1/1 daemons up, 1 hot standby
+    osd:        3 osds: 3 up (since 2w), 3 in (since 2w)
+    rbd-mirror: 1 daemon active (1 hosts)
+    rgw:        1 daemon active (1 hosts, 1 zones)
+
+  data:
+    volumes: 1/1 healthy
+    pools:   12 pools, 185 pgs
+    objects: 1.25k objects, 2.5 GiB
+    usage:   9.9 GiB used, 290 GiB / 300 GiB avail
+    pgs:     185 active+clean
+
+  io:
+    client:   18 KiB/s rd, 86 KiB/s wr, 22 op/s rd, 9 op/s wr
+
+
+Info: running mirroring daemon health
+health: WARNING
+daemon health: OK
+image health: WARNING
+images: 4 total
+    2 unknown
+    2 replaying
 ```


### PR DESCRIPTION
adding get sub-command `dr-health` which prints the
ceph status of peer cluster.