### PR TITLE
Bug 2275935: core: "ceph osd safe-to-destroy <osd-id>" returns an error but the odf-cli tool should not raise an exception

### DIFF
--- a/pkg/rook/osd/osd.go
+++ b/pkg/rook/osd/osd.go
@@ -54,7 +54,7 @@ func SafeToDestroy(ctx context.Context, clientsets *k8sutil.Clientsets, operator
 	args := []string{"osd", "safe-to-destroy", osdID}
 	out, err := exec.RunCommandInOperatorPod(ctx, clientsets, "ceph", args, operatorNamespace, storageClusterNamespace, true)
 	if err != nil {
-		logging.Fatal(fmt.Errorf("failed to run ceph command with args %v. %v", args, err))
+		return false, errors.Wrapf(err, string(out))
 	}
 
 	var safeToDestroy SafeToDestroyStatus


### PR DESCRIPTION
The command "ceph osd safe-to-destroy <osd-id>" returns an error but odf-cli tool should not raise an exception.

If the command "ceph osd safe-to-destroy <osd-id>" returns an error we need to add FORCE FLAG:

```
sh-5.1$ ceph osd safe-to-destroy 0 --connect-timeout=10 --conf=/var/lib/rook/openshift-storage/openshift-storage.config
Error EAGAIN: OSD(s) 0 have no reported stats, and not all PGs are active+clean; we cannot draw any conclusions. 
```
```
$ oc process -n openshift-storage ocs-osd-removal -p FAILED_OSD_IDS=${osd_id_to_remove} FORCE_OSD_REMOVAL=true |oc create -n openshift-storage -f -
```

**Tested locally on my machine:**
1. Change the code
2. Build the image
```
oviner~/DEV_REPOS/odf-cli(bz-2275935)$ make build
gofmt -w ./cmd/odf/get/get_recovery_profile.go ./cmd/odf/get/dr_health.go ./cmd/odf/get/get.go ./cmd/odf/get/health.go ./cmd/odf/get/mon_endpoints.go ./cmd/odf/get/rook_status.go ./cmd/odf/purgeosd/purge_osd.go ./cmd/odf/root/root.go ./cmd/odf/set/ceph.go ./cmd/odf/set/log_level.go ./cmd/odf/set/set.go ./cmd/odf/set/set_recovery_profile.go ./cmd/odf/subvolume/subvolume.go ./cmd/odf/main.go ./cmd/odf/maintenance/maintenance.go ./cmd/odf/maintenance/start.go ./cmd/odf/maintenance/stop.go ./cmd/odf/operator/operator.go ./cmd/odf/operator/rook/restart.go ./cmd/odf/operator/rook/rook.go ./cmd/odf/operator/rook/set.go ./cmd/odf/restore/crds.go ./cmd/odf/restore/mon_quorum.go ./cmd/odf/restore/restore.go ./pkg/rook/osd/osd.go ./pkg/rook/logs.go

env GOOS=linux GOARCH=amd64 go build -o bin/odf  cmd/odf/main.go
```
```
$ ls bin/ -l
total 54788
-rwxrwxr-x. 1 oviner oviner 56100817 Apr 30 15:49 odf
```
4. Remove disk via vceneter [provider is vsphere]:
```
$ oc get pods rook-ceph-osd-2-77ffd7dc77-qbd79
NAME                               READY   STATUS             RESTARTS     AGE
rook-ceph-osd-2-77ffd7dc77-qbd79   1/2     CrashLoopBackOff   2 (9s ago)   46m
```
5. Run script:
```
oviner~/DEV_REPOS/odf-cli/bin(bz-2275935)$ ./odf purge-osd 2
Warning: Are you sure you want to purge osd.2? The OSD is *not* safe to destroy. This may lead to data loss. If you are sure the OSD should be purged, enter 'yes-force-destroy-osd'
yes-force-destroy-osd
Info: Running purge osd command
2024-04-30 13:00:30.635689 W | cephcmd: loaded admin secret from env var ROOK_CEPH_SECRET instead of from file
2024-04-30 13:00:30.635778 I | rookcmd: starting Rook v4.15.2-0.62c88d463a1f068556dd5e48b736ea5354cd79a0 with arguments 'rook ceph osd remove --osd-ids=2 --force-osd-removal=true'
2024-04-30 13:00:30.635782 I | rookcmd: flag values: --force-osd-removal=true, --help=false, --log-level=INFO, --osd-ids=2, --preserve-pvc=false
2024-04-30 13:00:30.635784 I | ceph-spec: parsing mon endpoints: a=172.30.243.95:3300,b=172.30.153.242:3300,c=172.30.231.231:3300
2024-04-30 13:00:30.654297 I | cephclient: writing config file /var/lib/rook/openshift-storage/openshift-storage.config
2024-04-30 13:00:30.655107 I | cephclient: generated admin config in /var/lib/rook/openshift-storage
2024-04-30 13:00:31.005373 I | cephosd: validating status of osd.2
2024-04-30 13:00:31.005396 I | cephosd: osd.2 is marked 'DOWN'
2024-04-30 13:00:31.367119 I | cephosd: marking osd.2 out
2024-04-30 13:00:32.797234 I | cephosd: osd.2 is NOT ok to destroy but force removal is enabled so proceeding with removal
2024-04-30 13:00:32.813297 I | cephosd: removing the OSD deployment "rook-ceph-osd-2"
2024-04-30 13:00:32.813330 I | op-k8sutil: removing deployment rook-ceph-osd-2 if it exists
2024-04-30 13:00:32.867530 I | op-k8sutil: Removed deployment rook-ceph-osd-2
2024-04-30 13:00:32.891047 I | op-k8sutil: "rook-ceph-osd-2" still found. waiting...
2024-04-30 13:00:36.908464 I | op-k8sutil: confirmed rook-ceph-osd-2 does not exist
2024-04-30 13:00:36.922099 I | cephosd: removing the osd prepare job "rook-ceph-osd-prepare-dfd50b2279639b69f69d8ac4aa87687f"
2024-04-30 13:00:36.983082 I | cephosd: removing the OSD PVC "ocs-deviceset-thin-csi-0-data-0r748f"
2024-04-30 13:00:37.014400 I | cephosd: purging osd.2
2024-04-30 13:00:37.463791 I | cephosd: attempting to remove host "ocs-deviceset-thin-csi-0-data-0r748f" from crush map if not in use
2024-04-30 13:00:38.480226 I | cephosd: removed CRUSH host "ocs-deviceset-thin-csi-0-data-0r748f"
2024-04-30 13:00:38.860827 I | cephosd: no ceph crash to silence
2024-04-30 13:00:38.860848 I | cephosd: completed removal of OSD 2
```
7. Check osd pod status:
```
$ oc get pods rook-ceph-osd-2-5b6b5dd744-96nsz
NAME                               READY   STATUS    RESTARTS   AGE
rook-ceph-osd-2-5b6b5dd744-96nsz   1/2     Running   0          14s
````




https://bugzilla.redhat.com/show_bug.cgi?id=2275935