### PR TITLE
core: remove hidden true from all cmd

### DIFF
--- a/cmd/odf/maintenance/maintenance.go
+++ b/cmd/odf/maintenance/maintenance.go
@@ -12,7 +12,6 @@ var MaintenanceCmd = &cobra.Command{
 	Short:              "Perform maintenance operation on mons and OSDs deployment by scaling it down and creating a maintenance deployment.",
 	DisableFlagParsing: true,
 	Args:               cobra.ExactArgs(1),
-	Hidden:             true,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// verify operator pod is running
 		k8sutil.WaitForPodToRun(cmd.Context(), root.ClientSets.Kube, root.OperatorNamespace, "app=rook-ceph-operator")

--- a/cmd/odf/operator/operator.go
+++ b/cmd/odf/operator/operator.go
@@ -7,10 +7,9 @@ import (
 
 // OperatorCmd represents the rook commands
 var OperatorCmd = &cobra.Command{
-	Use:    "operator",
-	Short:  "Calls subcommands specific to various ODF operators",
-	Args:   cobra.ExactArgs(1),
-	Hidden: true,
+	Use:   "operator",
+	Short: "Calls subcommands specific to various ODF operators",
+	Args:  cobra.ExactArgs(1),
 }
 
 func init() {

--- a/cmd/odf/restore/restore.go
+++ b/cmd/odf/restore/restore.go
@@ -8,7 +8,6 @@ import (
 var RestoreCrd = &cobra.Command{
 	Use:                "restore",
 	DisableFlagParsing: true,
-	Hidden:             true,
 }
 
 func init() {


### PR DESCRIPTION
since with 4.17, all the commands will GA'ed removing `Hidden: true` which hides the command from the help section.