### PR TITLE
ceph: add support to run all ceph command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The ODF CLI tool provides configuration and troubleshooting commands for OpenShi
 - `odf restore`:
   - `mon-quorum`: Restore the mon quorum based on a single healthy mon since quorum was lost with the other mons
   - `deleted`: Restore the ceph resources which are stuck in deleting state due to underlying resources being present in the cluster
+- `odf ceph <args>` : Run a Ceph CLI command. Supports any arguments the ceph command supports. See [Ceph](https://docs.ceph.com/en/pacific/start/intro/) docs for more.
+- `odf rados <args>` : Run a Rados CLI command. Supports any arguments the rados command supports. See [Rados](https://docs.ceph.com/en/latest/man/8/rados/) docs for more.
+- `odf radosgw-admin <args>` : Run an RGW CLI command. Supports any arguments the [radosgw-admin](https://docs.ceph.com/en/latest/man/8/radosgw-admin/) command supports. See the radosgw-admin docs for more.
+- `odf rbd <args>` : Call a 'rbd' CLI command with arbitrary args
 - `odf help` : Display help text
 
 ## Documentation
@@ -44,6 +48,10 @@ Visit docs below for complete details about each command and their flags uses.
 - [mon](docs/mons.md)
 - [maintenance](docs/maintenance.md)
 - [operator](docs/operator.md)
+- [ceph](docs/ceph.md)
+- [rbd](docs/ceph.md#rbd)
+- [rados](docs/ceph.md#rados)
+- [radosgw-admin](docs/ceph.md#radosgw-admin)
 
 ### Root args
 

--- a/cmd/odf/ceph/ceph.go
+++ b/cmd/odf/ceph/ceph.go
@@ -1,0 +1,54 @@
+package ceph
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/red-hat-storage/odf-cli/cmd/odf/root"
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"github.com/spf13/cobra"
+)
+
+// CephCmd represents the ceph command
+var CephCmd = &cobra.Command{
+	Use:                "ceph",
+	Short:              "call a 'ceph' CLI command with arbitrary args",
+	DisableFlagParsing: true,
+	Args:               cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		logging.Info("running 'ceph' command with args: %v", args)
+		// verify operator pod is running
+		_, err := k8sutil.WaitForPodToRun(cmd.Context(), root.ClientSets.Kube, root.OperatorNamespace, "app=rook-ceph-operator")
+		if err != nil {
+			logging.Fatal(err)
+		}
+		if args[0] == "daemon" {
+			if len(args) < 2 {
+				logging.Fatal(fmt.Errorf("too few arguments to run the 'ceph daemon' command"))
+			}
+			cephDaemonNameAndID := splitCephDaemonNameAndID(args[1])
+
+			podLabel := fmt.Sprintf("%s=%s", cephDaemonNameAndID[0], cephDaemonNameAndID[1])
+			_, err = exec.RunCommandInLabeledPod(cmd.Context(), root.ClientSets, podLabel, cephDaemonNameAndID[0], cmd.Use, args, root.StorageClusterNamespace, false)
+			if err != nil {
+				logging.Fatal(err)
+			}
+
+		} else {
+			_, err = exec.RunCommandInOperatorPod(cmd.Context(), root.ClientSets, cmd.Use, args, root.OperatorNamespace, root.StorageClusterNamespace, false)
+			if err != nil {
+				logging.Fatal(err)
+			}
+		}
+	},
+}
+
+// splitCephDaemonNameAndID splits the arg based on '.' so that we use it with label, example osd.0 to osd and 0
+func splitCephDaemonNameAndID(args string) []string {
+	if !strings.Contains(args, ".") {
+		logging.Fatal(fmt.Errorf("Invalid argument to 'ceph daemon' command: %v. The arg should be in the format of '<daemon.id>'", args))
+	}
+	return strings.Split(args, ".")
+}

--- a/cmd/odf/ceph/rados.go
+++ b/cmd/odf/ceph/rados.go
@@ -1,0 +1,23 @@
+package ceph
+
+import (
+	"github.com/red-hat-storage/odf-cli/cmd/odf/root"
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"github.com/spf13/cobra"
+)
+
+// RadosCmd represents the rados command
+var RadosCmd = &cobra.Command{
+	Use:                "rados",
+	Short:              "call a 'rados' CLI command with arbitrary args",
+	DisableFlagParsing: true,
+	Args:               cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		logging.Info("running 'rados' command with args: %v", args)
+		_, err := exec.RunCommandInOperatorPod(cmd.Context(), root.ClientSets, cmd.Use, args, root.OperatorNamespace, root.StorageClusterNamespace, false)
+		if err != nil {
+			logging.Fatal(err)
+		}
+	},
+}

--- a/cmd/odf/ceph/radosgw.go
+++ b/cmd/odf/ceph/radosgw.go
@@ -1,0 +1,30 @@
+package ceph
+
+import (
+	"github.com/red-hat-storage/odf-cli/cmd/odf/root"
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"github.com/spf13/cobra"
+)
+
+// RadosgwCmd represents the radosgw command
+var RadosgwCmd = &cobra.Command{
+	Use:                "radosgw-admin",
+	Short:              "call a 'radosgw-admin' CLI command",
+	DisableFlagParsing: true,
+	Args:               cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		logging.Info("running 'radosgw-admin' command with args: %v", args)
+		// verify operator pod is running
+		_, err := k8sutil.WaitForPodToRun(cmd.Context(), root.ClientSets.Kube, root.OperatorNamespace, "app=rook-ceph-operator")
+		if err != nil {
+			logging.Fatal(err)
+		}
+
+		_, err = exec.RunCommandInOperatorPod(cmd.Context(), root.ClientSets, cmd.Use, args, root.OperatorNamespace, root.StorageClusterNamespace, false)
+		if err != nil {
+			logging.Fatal(err)
+		}
+	},
+}

--- a/cmd/odf/ceph/rbd.go
+++ b/cmd/odf/ceph/rbd.go
@@ -1,0 +1,30 @@
+package ceph
+
+import (
+	"github.com/red-hat-storage/odf-cli/cmd/odf/root"
+	"github.com/rook/kubectl-rook-ceph/pkg/exec"
+	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"github.com/spf13/cobra"
+)
+
+// RbdCmd represents the rbd command
+var RbdCmd = &cobra.Command{
+	Use:                "rbd",
+	Short:              "call a 'rbd' CLI command with arbitrary args",
+	DisableFlagParsing: true,
+	Args:               cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		logging.Info("running 'rbd' command with args: %v", args)
+		// verify operator pod is running
+		_, err := k8sutil.WaitForPodToRun(cmd.Context(), root.ClientSets.Kube, root.OperatorNamespace, "app=rook-ceph-operator")
+		if err != nil {
+			logging.Fatal(err)
+		}
+
+		_, err = exec.RunCommandInOperatorPod(cmd.Context(), root.ClientSets, cmd.Use, args, root.OperatorNamespace, root.StorageClusterNamespace, false)
+		if err != nil {
+			logging.Fatal(err)
+		}
+	},
+}

--- a/cmd/odf/main.go
+++ b/cmd/odf/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/red-hat-storage/odf-cli/cmd/odf/ceph"
 	"github.com/red-hat-storage/odf-cli/cmd/odf/get"
 	"github.com/red-hat-storage/odf-cli/cmd/odf/maintenance"
 	"github.com/red-hat-storage/odf-cli/cmd/odf/operator"
@@ -29,5 +30,9 @@ func addcommands() {
 		maintenance.MaintenanceCmd,
 		operator.OperatorCmd,
 		restore.RestoreCrd,
+		ceph.CephCmd,
+		ceph.RadosgwCmd,
+		ceph.RbdCmd,
+		ceph.RadosCmd,
 	)
 }

--- a/docs/ceph.md
+++ b/docs/ceph.md
@@ -1,0 +1,92 @@
+# Ceph Commnads
+
+Commands in this doc are an alternate to running the toolbox pod.
+
+## ceph
+
+Run the `ceph` cli command with with arbitrary args.
+
+### Example
+
+```bash
+odf ceph status
+
+#   cluster:
+#     id:     b74c18dd-6ee3-44fe-90b5-ed12feac46a4
+#     health: HEALTH_OK
+#
+#   services:
+#     mon: 3 daemons, quorum a,b,c (age 62s)
+#     mgr: a(active, since 23s)
+#     osd: 1 osds: 1 up (since 12s), 1 in (since 30s)
+#
+#   data:
+#     pools:   0 pools, 0 pg
+#     objects: 0 objects, 0 B
+#     usage:   0 B used, 0 B / 0 B avail
+#     pgs:
+```
+
+## ceph daemon
+
+Run the Ceph daemon command by connecting to its admin socket.
+
+```bash
+odf ceph daemon osd.0 dump_historic_ops
+
+Info: running 'ceph' command with args: [daemon osd.0 dump_historic_ops]
+{
+    "size": 20,
+    "duration": 600,
+    "ops": []
+}
+```
+
+## rados
+
+Run any `rados` cli command with with arbitrary args.
+
+### Example
+
+```bash
+odf rados df
+
+# POOL_NAME     USED  OBJECTS  CLONES  COPIES  MISSING_ON_PRIMARY  UNFOUND  DEGRADED  RD_OPS      RD  WR_OPS       WR  USED COMPR  UNDER COMPR
+# .mgr       452 KiB        2       0       2                   0        0         0      22  18 KiB      14  262 KiB         0 B          0 B
+
+# total_objects    2
+# total_used       27 MiB
+# total_avail      10 GiB
+# total_space      10 GiB
+```
+
+## rbd
+
+Run any `rbd` cli command with with arbitrary args.
+
+### Example
+
+```bash
+odf rbd ls replicapool
+
+# csi-vol-427774b4-340b-11ed-8d66-0242ac110004
+```
+
+## radosgw-admin
+
+Run any `radosgw-admin` cli command with arbitrary args.
+
+### Example
+
+```bash
+odf radosgw-admin user create --display-name="my user" --uid=myuser
+
+# Info: running 'radosgw-admin' command with args: [user create --display-name=my-user --uid=myuser]
+# {
+#     "user_id": "myuser",
+#     "display_name": "my user",
+#    ...
+#    ...
+#    ...
+# }
+```


### PR DESCRIPTION
this commit add support to run all the ceph commands without the need of having toolbox pod but this will be hidden command and will not be visible in help section.