### PR TITLE
Updated go1.23.0 to go 1.23.5 as CVE-2024-45336 is fixed in go 1.23.5…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/odf-cli
 
 go 1.23.0
 
-toolchain go1.23.4
+toolchain go1.23.5
 
 require (
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
odf-cli  security vulnerability issue.

Issue: [CVE-2024-45336](https://access.redhat.com/security/cve/CVE-2024-45336) golang: net/http: net/http: sensitive headers incorrectly sent after cross-domain redirect

The present version of go1.23.0 is upgraded to go 1.23.5 as this issue is fixed in l.23.5. 
