### PR TITLE
Enhance rbd ls Command to List Images Without Requiring an Image Name

### DIFF
--- a/cmd/odf/ceph/rbd.go
+++ b/cmd/odf/ceph/rbd.go
@@ -2,9 +2,9 @@ package ceph
 
 import (
 	"github.com/red-hat-storage/odf-cli/cmd/odf/root"
-	"github.com/rook/kubectl-rook-ceph/pkg/exec"
 	"github.com/rook/kubectl-rook-ceph/pkg/k8sutil"
 	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+	"github.com/rook/kubectl-rook-ceph/pkg/rbd"
 	"github.com/spf13/cobra"
 )
 
@@ -14,17 +14,21 @@ var RbdCmd = &cobra.Command{
 	Short:              "call a 'rbd' CLI command with arbitrary args",
 	DisableFlagParsing: true,
 	Args:               cobra.MinimumNArgs(1),
+}
+
+var listCmdRbd = &cobra.Command{
+	Use:   "ls",
+	Short: "Print the list of rbd images.",
 	Run: func(cmd *cobra.Command, args []string) {
-		logging.Info("running 'rbd' command with args: %v", args)
 		// verify operator pod is running
 		_, err := k8sutil.WaitForPodToRun(cmd.Context(), root.ClientSets.Kube, root.OperatorNamespace, "app=rook-ceph-operator")
 		if err != nil {
 			logging.Fatal(err)
 		}
-
-		_, err = exec.RunCommandInOperatorPod(cmd.Context(), root.ClientSets, cmd.Use, args, root.OperatorNamespace, root.StorageClusterNamespace, false)
-		if err != nil {
-			logging.Fatal(err)
-		}
+		rbd.ListImages(cmd.Context(), root.ClientSets, root.OperatorNamespace, root.StorageClusterNamespace)
 	},
+}
+
+func init() {
+	RbdCmd.AddCommand(listCmdRbd)
 }


### PR DESCRIPTION
This PR introduces support for running the `rbd ls` command without having to specify an image name. 
When a user executes odf `rbd ls` with no additional arguments, the command now directly invokes the vendor’s ListImages function (rook-kubectl upstream) to display a detailed table listing of available images (including pool name, image name, and namespace). 
If an image name (or extra arguments) is provided (e.g., odf rbd ls <pool>), the command continues to run in the operator pod as before, ensuring backward compatibility while improving the user experience for simple image listing.


````

$ ./bin/odf rbd ls
Info: running 'rbd' command with args: [ls]
poolName                          imageName                                     namespace  
--------                          ---------                                     ---------  
ocs-storagecluster-cephblockpool  csi-vol-068af78a-7b07-4a6c-85ff-7ec99ceefc91  ---        
ocs-storagecluster-cephblockpool  csi-vol-27d3721c-b59f-46f5-95d9-914456eb20c5  ---        
ocs-storagecluster-cephblockpool  csi-vol-9ed88240-d269-497d-9c2c-f67357763196  ---        
ocs-storagecluster-cephblockpool  csi-vol-dd2684a1-af48-4ca0-9fcc-3a3361780fe0  ---        
ocs-storagecluster-cephblockpool  csi-vol-fad8233b-94c4-4af5-bb84-60d7b1d06271  ---        

$ ./bin/odf rbd ls ocs-storagecluster-cephblockpool
Info: running 'rbd' command with args: [ls ocs-storagecluster-cephblockpool]
csi-vol-068af78a-7b07-4a6c-85ff-7ec99ceefc91
csi-vol-27d3721c-b59f-46f5-95d9-914456eb20c5
csi-vol-9ed88240-d269-497d-9c2c-f67357763196
csi-vol-dd2684a1-af48-4ca0-9fcc-3a3361780fe0
csi-vol-fad8233b-94c4-4af5-bb84-60d7b1d06271

```