### PR TITLE
Add resource collection for benchmark

### DIFF
--- a/cmd/odf/benchmark/benchmark.go
+++ b/cmd/odf/benchmark/benchmark.go
@@ -1,0 +1,10 @@
+package benchmark
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var BenchmarkCmd = &cobra.Command{
+	Use:   "benchmark",
+	Short: "Benchmark commands for ODF CLI",
+}

--- a/cmd/odf/benchmark/benchmark_resources.go
+++ b/cmd/odf/benchmark/benchmark_resources.go
@@ -1,0 +1,30 @@
+package benchmark
+
+import (
+	"fmt"
+
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+
+	"github.com/red-hat-storage/odf-cli/pkg/benchmark"
+	"github.com/spf13/cobra"
+)
+
+var outputPath string
+
+var ResourceCmd = &cobra.Command{
+	Use:     "resources",
+	Short:   "Collect cluster resources like disks and network interfaces",
+	Example: "odf benchmark resources",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := benchmark.CollectResources(outputPath); err != nil {
+			return fmt.Errorf("failed to collect resources: %v", err)
+		}
+		logging.Info("Resources written to %s\n", outputPath)
+		return nil
+	},
+}
+
+func init() {
+	ResourceCmd.Flags().StringVarP(&outputPath, "output", "o", "resources.json", "Output file for resources JSON")
+	BenchmarkCmd.AddCommand(ResourceCmd)
+}

--- a/cmd/odf/benchmark/benchmark_run.go
+++ b/cmd/odf/benchmark/benchmark_run.go
@@ -1,0 +1,25 @@
+package benchmark
+
+import (
+	"github.com/red-hat-storage/odf-cli/pkg/benchmark"
+	"github.com/spf13/cobra"
+)
+
+var (
+	resourcesPath     string = "resources.json"
+	daemonsetYamlPath string = "https://raw.githubusercontent.com/manishym/odf-benchmarker/refs/heads/main/daemonSet.yaml"
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run benchmark tests on the cluster",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return benchmark.RunBenchmarkWorkflow(resourcesPath, daemonsetYamlPath)
+	},
+}
+
+func init() {
+	runCmd.Flags().StringVar(&resourcesPath, "resources", resourcesPath, "Path to combined benchmark.json")
+	runCmd.Flags().StringVar(&daemonsetYamlPath, "daemonset", daemonsetYamlPath, "Path to daemonset YAML")
+	BenchmarkCmd.AddCommand(runCmd)
+}

--- a/cmd/odf/main.go
+++ b/cmd/odf/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/red-hat-storage/odf-cli/cmd/odf/benchmark"
 	"github.com/red-hat-storage/odf-cli/cmd/odf/ceph"
 	"github.com/red-hat-storage/odf-cli/cmd/odf/dr"
 	"github.com/red-hat-storage/odf-cli/cmd/odf/get"
@@ -36,5 +37,6 @@ func addcommands() {
 		ceph.RbdCmd,
 		ceph.RadosCmd,
 		dr.DrCmd,
+		benchmark.BenchmarkCmd,
 	)
 }

--- a/pkg/benchmark/benchmark_run.go
+++ b/pkg/benchmark/benchmark_run.go
@@ -1,0 +1,94 @@
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+)
+
+func RunBenchmarkWorkflow(resourcesJsonPath, daemonsetYamlPath string) error {
+	ctx := context.Background()
+
+	logging.Info("🚀 Creating ConfigMap from resources.json...")
+	createCmd := exec.CommandContext(ctx, "oc", "create", "configmap", "benchmark-metrics", "--from-file=benchmark.json="+resourcesJsonPath, "--dry-run=client", "-o", "yaml")
+	applyCmd := exec.CommandContext(ctx, "oc", "apply", "-f", "-")
+
+	pipeReader, pipeWriter := io.Pipe()
+	createCmd.Stdout = pipeWriter
+	applyCmd.Stdin = pipeReader
+
+	if err := createCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start configmap creation: %v", err)
+	}
+	if err := applyCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start configmap apply: %v", err)
+	}
+
+	createCmd.Wait()
+	pipeWriter.Close()
+	applyCmd.Wait()
+	pipeReader.Close()
+
+	logging.Info("✅ ConfigMap applied. Applying DaemonSet...")
+	if out, err := exec.CommandContext(ctx, "oc", "apply", "-f", daemonsetYamlPath).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to apply daemonset: %v\n%s", err, string(out))
+	}
+
+	logging.Info("⏳ Waiting for benchmark pods to complete...")
+	for {
+		out, err := exec.CommandContext(ctx, "oc", "get", "pods", "-l", "app=odf-preinstall-benchmark", "--no-headers").Output()
+		if err != nil {
+			return fmt.Errorf("failed to get pods: %v", err)
+		}
+
+		lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+		complete := true
+		for _, line := range lines {
+			fields := strings.Fields(line)
+			if len(fields) > 2 && fields[2] != "Completed" && fields[2] != "Succeeded" {
+				complete = false
+				break
+			}
+		}
+		if complete {
+			logging.Info("✅ All benchmark pods completed.")
+			break
+		}
+		logging.Info("... still waiting")
+		time.Sleep(10 * time.Second)
+	}
+
+	logging.Info("📥 Collecting logs from all pods...")
+	out, err := exec.CommandContext(ctx, "oc", "get", "pods", "-l", "app=odf-preinstall-benchmark", "-o", "name").Output()
+	if err != nil {
+		return fmt.Errorf("failed to list benchmark pods: %v", err)
+	}
+
+	os.MkdirAll("benchmark-logs", 0755)
+	for _, pod := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.Split(pod, "/")[1]
+		logOut, err := exec.CommandContext(ctx, "oc", "logs", pod).Output()
+		if err != nil {
+			fmt.Printf("❌ Failed to get logs from %s: %v\n", name, err)
+			continue
+		}
+		os.WriteFile("benchmark-logs/"+name+".log", logOut, 0644)
+		fmt.Printf("✅ Logs saved for pod %s\n", name)
+	}
+
+	logging.Info("🧹 Cleaning up DaemonSet and pods...")
+	if out, err := exec.CommandContext(ctx, "oc", "delete", "daemonset", "odf-preinstall-benchmark").CombinedOutput(); err != nil {
+		fmt.Printf("⚠️ Failed to delete DaemonSet: %v\n%s", err, string(out))
+	} else {
+		logging.Info("✅ DaemonSet deleted")
+	}
+
+	return nil
+}

--- a/pkg/benchmark/resources.go
+++ b/pkg/benchmark/resources.go
@@ -1,0 +1,176 @@
+package benchmark
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/rook/kubectl-rook-ceph/pkg/logging"
+
+	"github.com/red-hat-storage/odf-cli/cmd/odf/root"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type NodeResource struct {
+	NodeName          string   `json:"node_name"`
+	Disks             []string `json:"disks"`
+	NetworkInterfaces []string `json:"network_interfaces"`
+}
+
+type ClusterResources struct {
+	Nodes []NodeResource `json:"nodes"`
+}
+
+func CollectResources(outputPath string) error {
+	nodes, err := getClusterNodes()
+	if err != nil {
+		return err
+	}
+
+	var resources ClusterResources
+
+	for _, node := range nodes {
+		logging.Info("Collecting data for node: %s\n", node)
+		disks, err := getNodeDisks(node)
+		if err != nil {
+			return err
+		}
+		nics, err := getNodeNics(node)
+		if err != nil {
+			return err
+		}
+
+		resources.Nodes = append(resources.Nodes, NodeResource{
+			NodeName:          node,
+			Disks:             disks,
+			NetworkInterfaces: nics,
+		})
+	}
+
+	jsonBytes, err := json.MarshalIndent(resources, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(outputPath, jsonBytes, 0644)
+}
+
+func getClusterNodes() ([]string, error) {
+
+	nodeList, err := root.ClientSets.Kube.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %v", err)
+	}
+
+	var nodeNames []string
+	for _, node := range nodeList.Items {
+		nodeNames = append(nodeNames, node.Name)
+	}
+	return nodeNames, nil
+}
+
+func getNodeDisks(nodeName string) ([]string, error) {
+	cmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "lsblk", "-d", "-n", "-o", "NAME")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get disks for node %s: %v", nodeName, err)
+	}
+	disks := parseLines(output)
+
+	mountedDisks, err := getMountedDisks(nodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	return filterUnmountedDisks(disks, mountedDisks), nil
+}
+
+func getMountedDisks(nodeName string) ([]string, error) {
+	cmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "lsblk", "-o", "NAME,MOUNTPOINT")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get mounted disks for node %s: %v", nodeName, err)
+	}
+	return parseMountedDisks(output), nil
+}
+
+func parseMountedDisks(output []byte) []string {
+	lines := strings.Split(string(output), "\n")
+	var mountedDisks []string
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) > 1 && fields[1] != "" { // Disk has a mountpoint
+			mountedDisks = append(mountedDisks, fields[0])
+		}
+	}
+	return mountedDisks
+}
+
+func filterUnmountedDisks(allDisks, mountedDisks []string) []string {
+	mountedSet := make(map[string]bool)
+	for _, disk := range mountedDisks {
+		mountedSet[disk] = true
+	}
+
+	var unmountedDisks []string
+	for _, disk := range allDisks {
+		if !mountedSet[disk] {
+			unmountedDisks = append(unmountedDisks, disk)
+		}
+	}
+	return unmountedDisks
+}
+
+func parseLines(output []byte) []string {
+	lines := strings.Split(string(output), "\n")
+	var result []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func getNodeNics(nodeName string) ([]string, error) {
+	cmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "ip", "-o", "link", "show")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get NICs for node %s: %v", nodeName, err)
+	}
+	return filterPhysicalInterfaces(parseNicLines(output)), nil
+}
+
+func parseNicLines(output []byte) []string {
+	lines := strings.Split(string(output), "\n")
+	var interfaces []string
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) > 1 {
+			iface := strings.TrimSuffix(fields[1], ":") // Ensure we remove only the colon
+			interfaces = append(interfaces, iface)
+		}
+	}
+	return interfaces
+}
+
+func filterPhysicalInterfaces(nics []string) []string {
+	var filtered []string
+	for _, nic := range nics {
+		if strings.HasPrefix(nic, "lo") || // Ignore loopback
+			strings.HasPrefix(nic, "br-") || // Ignore OVS bridges
+			strings.HasPrefix(nic, "ovs-") || // Ignore Open vSwitch
+			strings.HasPrefix(nic, "ovn-") || // Ignore OVN tunnels
+			strings.HasPrefix(nic, "genev_sys") || // Ignore geneve tunnels
+			len(nic) > 15 { // Ignore hashed virtual interfaces
+			continue
+		}
+		filtered = append(filtered, nic)
+	}
+	return filtered
+}

--- a/pkg/benchmark/resources_test.go
+++ b/pkg/benchmark/resources_test.go
@@ -1,0 +1,51 @@
+// Unit tests
+package benchmark
+
+import "testing"
+
+func TestParseNicLines(t *testing.T) {
+	sampleOutput := []byte(
+		`1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+         2: eth0@if24: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default`,
+	)
+	expected := []string{"lo", "eth0@if24"} // Ensure @ interface names are preserved
+	result := parseNicLines(sampleOutput)
+
+	if len(result) != len(expected) {
+		t.Errorf("Expected length %d, got %d", len(expected), len(result))
+	}
+
+	for i := range expected {
+		if result[i] != expected[i] {
+			t.Errorf("Expected %v, got %v", expected, result)
+		}
+	}
+}
+
+func TestFilterPhysicalInterfaces(t *testing.T) {
+	sampleNics := []string{"lo", "br-ex", "eth0", "ovs-system", "ens5", "ovn-k8s-mp0"}
+	expected := []string{"eth0", "ens5"}
+	result := filterPhysicalInterfaces(sampleNics)
+	if len(result) != len(expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+func TestParseMountedDisks(t *testing.T) {
+	sampleOutput := []byte("sda /mnt/data\nsdb \nsdc /var/lib\nsdd \n")
+	expected := []string{"sda", "sdc"}
+	result := parseMountedDisks(sampleOutput)
+	if len(result) != len(expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+func TestFilterUnmountedDisks(t *testing.T) {
+	allDisks := []string{"sda", "sdb", "sdc", "sdd"}
+	mountedDisks := []string{"sda", "sdc"}
+	expected := []string{"sdb", "sdd"}
+	result := filterUnmountedDisks(allDisks, mountedDisks)
+	if len(result) != len(expected) {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}


### PR DESCRIPTION
Add resource collection for benchmark
- Implemented `benchmark resources` command to collect cluster resources.
- Added detection of available disks and network interfaces for each node.
- Introduced filtering of mounted disks to ensure only unmounted disks are used for benchmarking.
- Improved NIC collection by filtering out virtual interfaces, bridges, and Open vSwitch interfaces.
- Added unit tests for mounted disk parsing and filtering to ensure correctness.
- `benchmark run` command to run and collect benchmark metrics

Signed-off-by: Manish <myathnal@redhat.com>