### PR TITLE
Minor improvements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,7 @@ These are the arguments that apply to all commands:
 
 ## Installation
 
-### Build from source
-
-#### Requirements
-
-- Go >= 1.22.0
-- ODF storage cluster should be installed.
-
-### Build and Run
+### Build and run from source
 
 1. Clone the repository
 
@@ -107,10 +100,11 @@ These are the arguments that apply to all commands:
 2. Change the directory and build the binary
 
     ```bash
-    cd odf-cli/ && make build
+    cd odf-cli/
+    make
     ```
 
-3. Use the binary present in the`/bin/` directory to run the commands
+3. Use the binary present in the `bin/` directory to run the commands
 
     ```bash
     ./bin/odf -h


### PR DESCRIPTION
- Remove the Requirements section since users know how to find the 
  required version using go.mod, and ODF cluster is not required to
  build the binary.
- Improve the heading to describe the content
- Simplify build instructions. `make build` works, but since it is the 
  default target (for good reason) we don't need to specify it. This is
  also the expected usage.
- Separate the build command to 2 lines for simplicity.
- Fix '/bin/' to 'bin/' adding missing space                                                                                               
