### PR TITLE
build(deps): update ramenctl to v0.3.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/red-hat-storage/odf-cli
 
-go 1.23.0
+go 1.23.5
 
-toolchain go1.23.4
+toolchain go1.23.7
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/ramendr/ramenctl v0.3.1
+	github.com/ramendr/ramenctl v0.3.4
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d
 	github.com/rook/kubectl-rook-ceph v0.9.3
 	github.com/rook/rook v1.16.5
@@ -84,7 +84,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 // indirect
-	github.com/ramendr/ramen/e2e v0.0.0-20250329065458-d36833ab0386 // indirect
+	github.com/ramendr/ramen/e2e v0.0.0-20250404093316-3bc6c2453c1d // indirect
 	github.com/rook/rook/pkg/apis v0.0.0-20241216163035-3170ac6a0c58 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -729,10 +729,10 @@ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoG
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250329065458-d36833ab0386 h1:xhc9BhbcgtrE/K/gplYInnd4DkNltOHFIy5J853KyEw=
-github.com/ramendr/ramen/e2e v0.0.0-20250329065458-d36833ab0386/go.mod h1:T0E9hZ6IoV0sfz0bC/JzZuLQVk9Hfzkabw7ZnMJgGrw=
-github.com/ramendr/ramenctl v0.3.1 h1:FkC0vmmIUosO2ci3ZZvzrzGAaTYAk34YlroYFfVOr1Y=
-github.com/ramendr/ramenctl v0.3.1/go.mod h1:Bh8oX6sieo+WYNlDlUifY5QrpSzFPApNIpNDwtL8ehA=
+github.com/ramendr/ramen/e2e v0.0.0-20250404093316-3bc6c2453c1d h1:MVW5GO88K8e6D+gsiEIfIn7WjVS+z3RDEDpEnxLLKRc=
+github.com/ramendr/ramen/e2e v0.0.0-20250404093316-3bc6c2453c1d/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramenctl v0.3.4 h1:YbT8Egkz/2QAShK1dYPaCDCBlfeZpvCNj/LlTQDRzGU=
+github.com/ramendr/ramenctl v0.3.4/go.mod h1:zFBynKLXRnTLZ/yjLAmdYCrxfF2BrA9+/vTE0bAz8is=
 github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d h1:/AnA3CccDrZZfgaJSKIWMZOznzq2k5W9CXmj4Vyhxik=
 github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d/go.mod h1:kbtILVV15bhm4UFehDYhezjZIvbeaZQ/4vQdv2gagdk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
Fixes includes in this version:
- https://github.com/RamenDR/ramenctl/issues/56
- https://github.com/RamenDR/ramenctl/pull/96
- https://github.com/RamenDR/ramenctl/pull/93

ramenctl requires now go 1.23.5, fixing CVE-2024-45336 (because of github.com/ramendr/ramen/e2e). `go mod tidy` updated the toolchain to go1.24.1, but I change it to go1.23.7 to minimize the chance of picking up packages that are not compatible with the downstream build.

With this version applications deployed by `odf dr test run` command can be viewed and manipulated in OpenShift console. This can be useful if the `odf dr test clean` was not run.