### PR TITLE
docs: add download-odf-nightly.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,15 @@ These are the arguments that apply to all commands:
     ```bash
     ./bin/odf -h
     ```
+
+### Download nightly build
+
+If you want to test the latest nightly build you can use the
+download-odf-nightly.sh script:
+
+```bash
+scripts/download-odf-nightly.sh v4.19
+```
+
+The command downloads the latest 4.19 build image and extracts the odf
+executable to the current directory.

--- a/scripts/download-odf-nightly.sh
+++ b/scripts/download-odf-nightly.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Download a nightly build of odf cli executable for the current platform and
+# architecture.
+
+set -e
+
+version="$1"
+
+if [ -z "$version" ]; then
+    cat <<EOF
+Usage: $0 VERSION
+
+Examples:
+
+  $0 v4.19
+
+EOF
+    exit 1
+fi
+
+image="quay.io/rhceph-dev/odf4-odf-cli-rhel9:$version"
+platform=$(uname)
+
+case $platform in
+Darwin)
+    platform=macosx
+    executable=odf
+    ;;
+Linux)
+    platform=linux
+    machine=$(uname -m)
+    case $machine in
+    x86_64)
+        executable=odf-amd64
+        ;;
+    aarch64)
+        executable=odf-arm64
+        ;;
+    ppc64le,s390x)
+        executable=odf-$machine
+        ;;
+    *)
+        echo "unsupported machine $machine"
+        exit 1
+        ;;
+    esac
+    ;;
+*)
+    echo "unsupported platform $platform"
+    exit 1
+    ;;
+esac
+
+# We have only linux/amd64, linux/s390x, and linux/ppc64le images. The
+# linux/amd64 image includes builds for all platforms.
+oc image extract "$image" \
+    --filter-by-os "^linux/amd64" \
+    --file "/usr/share/odf/$platform/$executable"
+
+chmod +x "$executable"
+
+if [ "$executable" != "odf" ]; then
+    mv "$executable" odf
+fi


### PR DESCRIPTION
The script downloads a nightly build and extracts the odf executable to
the current directory. This makes it easier to test the latest odf
build.

We use the v4.19 tag, pointing to the latest v4.19.z image.

Tested on:
- [x] macOS arm64 (using x86_64 build via Rosetta)
- [x] Linux x86_64

This nightly image does not contain other architectures. When we will have multiarch images the script should work on any machine.