### PR TITLE
Add description for restore command in CLI help output

### DIFF
--- a/cmd/odf/restore/restore.go
+++ b/cmd/odf/restore/restore.go
@@ -8,6 +8,7 @@ import (
 var RestoreCrd = &cobra.Command{
 	Use:                "restore",
 	DisableFlagParsing: true,
+	Short:              "Restore deleted ODF custom resources (CRs)",
 }
 
 func init() {


### PR DESCRIPTION
This PR adds a help description for the restore command in the odf-cli.
```
$ ./bin/odf --help
Management and troubleshooting tools for ODF clusters.

Usage:
  odf [command]

Available Commands:
  benchmark     Benchmark commands for ODF CLI
  ceph          call a 'ceph' CLI command with arbitrary args
  dr            Troubleshoot ODF DR
  get           Get ODF configuration
  help          Help about any command
  maintenance   Perform maintenance operation on mons and OSDs deployment by scaling it down and creating a maintenance deployment.
  operator      Calls subcommands specific to various ODF operators
  purge-osd     Permanently remove an OSD from the cluster.
  rados         call a 'rados' CLI command with arbitrary args
  radosgw-admin call a 'radosgw-admin' CLI command
  rbd           call a 'rbd' CLI command with arbitrary args
  restore       Restore deleted ODF custom resources (CRs)
  set           Set ODF configuration
  subvolume     Manages subvolumes

Flags:
      --context string              Openshift context to use
  -h, --help                        help for odf
      --kubeconfig string           Openshift config path
  -n, --namespace string            Openshift namespace where the StorageCluster CR is created (default "openshift-storage")
      --operator-namespace string   Openshift namespace where the ODF operator is running

Use "odf [command] --help" for more information about a command.
```
This improves clarity and consistency in the CLI help output.

Fixes: #156 
