### PR TITLE
dr: add the `odf dr validate clusters` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The ODF CLI tool provides configuration and troubleshooting commands for OpenShi
     - `run`: Run disaster recovery test with a tiny application (developer preview)
     - `clean`: Clean up after running tests (developer preview)
   - `validate`:
-    - `application`: Detect disaster recovery problems (developer preview)
+    - `application`: Detect problems in disaster recovery protected application (developer preview)
+    - `clusters`: Detect problems in disaster recovery clusters (developer preview)
   - `gather`:
     - `application`: Collect diagnostic data from your clusters (developer preview)
 - `odf noobaa:` Run a noobaa CLI command. Supports all the noobaa cli arguments available in odf.

--- a/docs/dr.md
+++ b/docs/dr.md
@@ -293,6 +293,7 @@ current status of the clusters or protected applications.
 The command supports the following sub-commands:
 
 * [application](#validate-application)
+* [clusters](#validate-clusters)
 
 ### validate application
 
@@ -354,7 +355,7 @@ out
 The `validate-application.yaml` report is a machine and human readable
 description of the command and the application status.
 
-The most important part of the report is the applicationStatus:
+The most important part of the report is the `applicationStatus`:
 
 ```yaml
 applicationStatus:
@@ -463,6 +464,285 @@ out/validate-application.data
 
 This log includes detailed information that may help to troubleshoot the
 validate application command. If the command failed, check the error details in
+the log.
+
+### validate clusters
+
+The validate clusters command validates the disaster recovery clusters by
+gathering cluster scoped and related ramen resources from all clusters.
+
+### Validating clusters
+
+To validate the disaster recovery clusters, run the following command:
+
+```console
+$ odf dr validate clusters -o out
+⭐ Using config "config.yaml"
+⭐ Using report "out"
+
+🔎 Validate config ...
+   ✅ Config validated
+
+🔎 Validate clusters ...
+   ✅ Gathered data from cluster "hub"
+   ✅ Gathered data from cluster "dr1"
+   ✅ Gathered data from cluster "dr2"
+   ✅ Clusters validated
+
+✅ Validation completed (36 ok, 0 stale, 0 problem)
+```
+
+The command gathered cluster scoped and ramen resources from all clusters,
+inspected the resources, and stored output files in the specified output
+directory:
+
+```console
+$ tree -L1 out
+out
+├── validate-clusters.data
+├── validate-clusters.log
+└── validate-clusters.yaml
+```
+
+> [!IMPORTANT]
+> When reporting DR related issues, please create an archive with the output
+> directory and upload it to the issue tracker.
+
+#### The validate-clusters.yaml
+
+The `validate-clusters.yaml` report is a machine and human readable description
+of the command and the clusters status.
+
+The most important part of the report is the `clustersStatus`:
+
+```yaml
+clustersStatus:
+  clusters:
+  - name: dr1
+    ramen:
+      configmap:
+        deleted:
+          state: ok ✅
+        name: ramen-dr-cluster-operator-config
+        namespace: ramen-system
+        ramenControllerType:
+          state: ok ✅
+          value: dr-cluster
+        s3StoreProfiles:
+          state: ok ✅
+          value:
+          - s3ProfileName: minio-on-dr1
+            s3SecretRef:
+              state: ok ✅
+              value:
+                name: ramen-s3-secret-dr1
+                namespace: ramen-system
+          - s3ProfileName: minio-on-dr2
+            s3SecretRef:
+              state: ok ✅
+              value:
+                name: ramen-s3-secret-dr2
+                namespace: ramen-system
+      deployment:
+        conditions:
+        - state: ok ✅
+          type: Available
+        - state: ok ✅
+          type: Progressing
+        deleted:
+          state: ok ✅
+        name: ramen-dr-cluster-operator
+        namespace: ramen-system
+        replicas:
+          state: ok ✅
+          value: 1
+  - name: dr2
+    ramen:
+      configmap:
+        deleted:
+          state: ok ✅
+        name: ramen-dr-cluster-operator-config
+        namespace: ramen-system
+        ramenControllerType:
+          state: ok ✅
+          value: dr-cluster
+        s3StoreProfiles:
+          state: ok ✅
+          value:
+          - s3ProfileName: minio-on-dr1
+            s3SecretRef:
+              state: ok ✅
+              value:
+                name: ramen-s3-secret-dr1
+                namespace: ramen-system
+          - s3ProfileName: minio-on-dr2
+            s3SecretRef:
+              state: ok ✅
+              value:
+                name: ramen-s3-secret-dr2
+                namespace: ramen-system
+      deployment:
+        conditions:
+        - state: ok ✅
+          type: Progressing
+        - state: ok ✅
+          type: Available
+        deleted:
+          state: ok ✅
+        name: ramen-dr-cluster-operator
+        namespace: ramen-system
+        replicas:
+          state: ok ✅
+          value: 1
+  hub:
+    drClusters:
+      state: ok ✅
+      value:
+      - conditions:
+        - state: ok ✅
+          type: Fenced
+        - state: ok ✅
+          type: Clean
+        - state: ok ✅
+          type: Validated
+        name: dr1
+        phase: Available
+      - conditions:
+        - state: ok ✅
+          type: Fenced
+        - state: ok ✅
+          type: Clean
+        - state: ok ✅
+          type: Validated
+        name: dr2
+        phase: Available
+    drPolicies:
+      state: ok ✅
+      value:
+      - conditions:
+        - state: ok ✅
+          type: Validated
+        drClusters:
+        - dr1
+        - dr2
+        name: dr-policy
+        schedulingInterval: 1m
+    ramen:
+      configmap:
+        deleted:
+          state: ok ✅
+        name: ramen-hub-operator-config
+        namespace: ramen-system
+        ramenControllerType:
+          state: ok ✅
+          value: dr-hub
+        s3StoreProfiles:
+          state: ok ✅
+          value:
+          - s3ProfileName: minio-on-dr1
+            s3SecretRef:
+              state: ok ✅
+              value:
+                name: ramen-s3-secret-dr1
+                namespace: ramen-system
+          - s3ProfileName: minio-on-dr2
+            s3SecretRef:
+              state: ok ✅
+              value:
+                name: ramen-s3-secret-dr2
+                namespace: ramen-system
+      deployment:
+        conditions:
+        - state: ok ✅
+          type: Available
+        - state: ok ✅
+          type: Progressing
+        deleted:
+          state: ok ✅
+        name: ramen-hub-operator
+        namespace: ramen-system
+        replicas:
+          state: ok ✅
+          value: 1
+```
+
+#### The validate-clusters.data directory
+
+This directory contains all data gathered during validation. Use the gathered
+data to investigate the problems reported in the `validate-clusters.yaml` report.
+
+```console
+$ tree -L3 out/validate-clusters.data
+out/validate-clusters.data
+├── dr1
+│   ├── cluster
+│   │   ├── apiextensions.k8s.io
+│   │   ├── apiregistration.k8s.io
+│   │   ├── cluster.open-cluster-management.io
+│   │   ├── flowcontrol.apiserver.k8s.io
+│   │   ├── namespaces
+│   │   ├── networking.k8s.io
+│   │   ├── nodes
+│   │   ├── operator.open-cluster-management.io
+│   │   ├── operators.coreos.com
+│   │   ├── persistentvolumes
+│   │   ├── ramendr.openshift.io
+│   │   ├── rbac.authorization.k8s.io
+│   │   ├── replication.storage.openshift.io
+│   │   ├── scheduling.k8s.io
+│   │   ├── snapshot.storage.k8s.io
+│   │   ├── storage.k8s.io
+│   │   ├── submariner.io
+│   │   └── work.open-cluster-management.io
+│   └── namespaces
+│       └── ramen-system
+├── dr2
+│   ├── cluster
+│   │   ├── apiextensions.k8s.io
+│   │   ├── apiregistration.k8s.io
+│   │   ├── cluster.open-cluster-management.io
+│   │   ├── flowcontrol.apiserver.k8s.io
+│   │   ├── namespaces
+│   │   ├── networking.k8s.io
+│   │   ├── nodes
+│   │   ├── operator.open-cluster-management.io
+│   │   ├── operators.coreos.com
+│   │   ├── persistentvolumes
+│   │   ├── ramendr.openshift.io
+│   │   ├── rbac.authorization.k8s.io
+│   │   ├── replication.storage.openshift.io
+│   │   ├── scheduling.k8s.io
+│   │   ├── snapshot.storage.k8s.io
+│   │   ├── storage.k8s.io
+│   │   ├── submariner.io
+│   │   └── work.open-cluster-management.io
+│   └── namespaces
+│       └── ramen-system
+└── hub
+    ├── cluster
+    │   ├── addon.open-cluster-management.io
+    │   ├── admissionregistration.k8s.io
+    │   ├── apiextensions.k8s.io
+    │   ├── apiregistration.k8s.io
+    │   ├── cluster.open-cluster-management.io
+    │   ├── flowcontrol.apiserver.k8s.io
+    │   ├── namespaces
+    │   ├── networking.k8s.io
+    │   ├── nodes
+    │   ├── operator.open-cluster-management.io
+    │   ├── operators.coreos.com
+    │   ├── ramendr.openshift.io
+    │   ├── rbac.authorization.k8s.io
+    │   ├── scheduling.k8s.io
+    │   └── storage.k8s.io
+    └── namespaces
+        └── ramen-system
+```
+
+#### The validate-clusters.log
+
+This log includes detailed information that may help to troubleshoot the
+validate clusters command. If the command failed, check the error details in
 the log.
 
 ## gather

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.19.0
 	github.com/pkg/errors v0.9.1
-	github.com/ramendr/ramenctl v0.10.1
+	github.com/ramendr/ramenctl v0.11.0
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d
 	github.com/rook/kubectl-rook-ceph v0.9.4
 	github.com/rook/rook v1.18.0
@@ -138,7 +138,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/nirs/kubectl-gather v0.10.0 // indirect
+	github.com/nirs/kubectl-gather v0.10.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/openshift/api v0.0.0-20241216151652-de9de05a8e43 // indirect
 	github.com/openshift/cloud-credential-operator v0.0.0-20231004191224-abdf0627a0cf // indirect

--- a/go.sum
+++ b/go.sum
@@ -2226,8 +2226,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nirs/kubectl-gather v0.10.0 h1:cjfiiA8EVnv88EubSJ2+Bekd7SgNXnrv3AlU2tATF4Y=
-github.com/nirs/kubectl-gather v0.10.0/go.mod h1:i6GaOi/I6imJ+8U8NLoEsp9Ukn/4kzXZx2ei6Af8MeI=
+github.com/nirs/kubectl-gather v0.10.1 h1:bI9RYh5YUn9WgxDGu4sYrlnrWTvu7c1+mrLk3NMDIfg=
+github.com/nirs/kubectl-gather v0.10.1/go.mod h1:i6GaOi/I6imJ+8U8NLoEsp9Ukn/4kzXZx2ei6Af8MeI=
 github.com/noobaa/noobaa-operator/v5 v5.19.0 h1:PtUbgAOl3Wg+YS39DGiCo/aujRL3j6lwJHVbcuneRSU=
 github.com/noobaa/noobaa-operator/v5 v5.19.0/go.mod h1:w3/B2Z/MMTW9TT2bsiN7VMlwfTwQL4KVARr0r7WKEvk=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -2409,8 +2409,8 @@ github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 h1:2hL/5Ofwx/7O2
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5/go.mod h1:vtuEN3pI8SD0WEp5jAPf2Bqi/3CeiuQZkNz6F52NIqo=
 github.com/ramendr/ramen/e2e v0.0.0-20250722150952-d4c9b950df94 h1:ts1Z8oSS0ozaenQqd2wQ3z6y//w29GYVmaHwXzoBrGo=
 github.com/ramendr/ramen/e2e v0.0.0-20250722150952-d4c9b950df94/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
-github.com/ramendr/ramenctl v0.10.1 h1:0c3z1tWyqHjaywtqnJKv316wjC/0HvWVqTxtm2XI3HE=
-github.com/ramendr/ramenctl v0.10.1/go.mod h1:PjaRtehKB/kazgZyegC2ys09LOjX1NmEtPIHg9PAWuU=
+github.com/ramendr/ramenctl v0.11.0 h1:D7e3VFi5abmfl+WYcyHBpgkZegpNPOx9/4wHAOGOLOY=
+github.com/ramendr/ramenctl v0.11.0/go.mod h1:pIXaTPR5t5fR18GkTN2FmoD2Bpv5aoRaDp1c4bLT0F4=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d h1:/AnA3CccDrZZfgaJSKIWMZOznzq2k5W9CXmj4Vyhxik=


### PR DESCRIPTION
Update ramenctl to v0.11.0, adding the new command and latest fixes to other commands:
https://github.com/RamenDR/ramenctl/releases/tag/v0.11.0

This is only dependency and docs change. The validate command includes now a new clusters sub command.

Example run:

    % odf dr validate clusters -o out
    ⭐ Using config "config.yaml"
    ⭐ Using report "out"

    🔎 Validate config ...
       ✅ Config validated

    🔎 Validate clusters ...
       ✅ Gathered data from cluster "hub"
       ✅ Gathered data from cluster "dr2"
       ✅ Gathered data from cluster "dr1"
       ✅ Clusters validated

    ✅ Validation completed (36 ok, 0 stale, 0 problem)