### PR TITLE
DFBUGS-3849:  mark odf dr commands as developer preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ The ODF CLI tool provides configuration and troubleshooting commands for OpenShi
 - `odf radosgw-admin <args>` : Run an RGW CLI command. Supports any arguments the [radosgw-admin](https://docs.ceph.com/en/latest/man/8/radosgw-admin/) command supports. See the radosgw-admin docs for more.
 - `odf rbd <args>` : Call a 'rbd' CLI command with arbitrary args
 - `odf dr`:
-  - `init`: Create configuration file for `odf dr` sub-commands.
+  - `init`: Create configuration file for `odf dr` sub-commands (developer preview)
   - `test`:
-    - `run`: Run distaster recovery test with a tiny application.
-    - `clean`: Clean up after running tests.
+    - `run`: Run disaster recovery test with a tiny application (developer preview)
+    - `clean`: Clean up after running tests (developer preview)
 - `odf help` : Display help text
 
 ## Documentation

--- a/cmd/odf/devpreview/devpreview.go
+++ b/cmd/odf/devpreview/devpreview.go
@@ -1,0 +1,48 @@
+package devpreview
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// Suffix for appending to the short command description.
+	Suffix = " (developer preview)"
+
+	// Note for appending to the long command description.
+	Note = `
++------------------------------------------------------------------------------+
+|                                                                              |
+|    This command is a developer preview, unsupported and not fully tested.    |
+|    Please see the following document for more info on developer preview:     |
+|    https://access.redhat.com/support/offerings/devpreview                    |
+|                                                                              |
++------------------------------------------------------------------------------+
+`
+)
+
+// Configure a command as a developer preview command. Mark the command hidden
+// and amend the command short and long descriptions. If the command has
+// children commands their short and long descriptions are amended as well.
+func Configure(cmd *cobra.Command) {
+	cmd.Hidden = true
+	amendDescriptions(cmd)
+}
+
+func amendDescriptions(cmd *cobra.Command) {
+	cmd.Short += Suffix
+
+	if cmd.Long != "" {
+		cmd.Long = strings.TrimRight(cmd.Long, "\n") + "\n" + Note
+	} else {
+		// If the long description is set the short description is not shown in
+		// the help text. Add the short description so we have more specific
+		// long description.
+		cmd.Long = strings.TrimRight(cmd.Short, "\n") + "\n" + Note
+	}
+
+	for _, child := range cmd.Commands() {
+		amendDescriptions(child)
+	}
+}

--- a/cmd/odf/devpreview/devpreview_test.go
+++ b/cmd/odf/devpreview/devpreview_test.go
@@ -1,0 +1,125 @@
+package devpreview_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/red-hat-storage/odf-cli/cmd/odf/devpreview"
+)
+
+const output = "OK"
+
+func TestConfigure(t *testing.T) {
+	t.Run("root", func(t *testing.T) {
+		root := testCommand()
+		devpreview.Configure(root)
+		checkCommand(t, root)
+	})
+
+	t.Run("child", func(t *testing.T) {
+		root := testCommand()
+		devpreview.Configure(root)
+		checkCommand(t, root, "child")
+	})
+
+	t.Run("grandchild1", func(t *testing.T) {
+		root := testCommand()
+		devpreview.Configure(root)
+		checkCommand(t, root, "child", "grandchild1")
+	})
+
+	t.Run("grandchild2", func(t *testing.T) {
+		root := testCommand()
+		devpreview.Configure(root)
+		checkCommand(t, root, "child", "grandchild2")
+	})
+}
+
+// Cobra remembers state from Execute() (e.g. --help flag), so we must use a
+// new command for every test.
+func testCommand() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "root",
+		Short: "root short",
+		Long:  "root long description",
+	}
+
+	child := &cobra.Command{
+		Use:   "child",
+		Short: "child short",
+		Long:  "child long description",
+	}
+
+	grandChild1 := &cobra.Command{
+		Use:   "grandchild1",
+		Short: "grand child 1 short",
+		Long:  "grand child 1 long description",
+		Run:   printOutput,
+	}
+
+	grandChild2 := &cobra.Command{
+		Use:   "grandchild2",
+		Short: "grand child 2 short",
+		Long:  "grand child 2 long description",
+		Run:   printOutput,
+	}
+
+	child.AddCommand(grandChild1, grandChild2)
+	root.AddCommand(child)
+
+	return root
+}
+
+func checkCommand(t *testing.T, root *cobra.Command, args ...string) {
+	args = append(args, "--help")
+	cmd, help, err := executeCommand(root, args...)
+	if err != nil {
+		t.Fatalf("running %q with args %q failed: %v", cmd.CommandPath(), args, err)
+	}
+
+	if cmd == root {
+		if !cmd.Hidden {
+			t.Fatal("root command should not be hidden")
+		}
+	} else if cmd.Hidden {
+		t.Fatal("child commands should not be hidden")
+	}
+
+	if !strings.HasSuffix(cmd.Short, devpreview.Suffix) {
+		t.Fatalf("command %q short does not include the developer preview suffix: %q",
+			cmd.CommandPath(), cmd.Short)
+	}
+
+	if !strings.HasSuffix(cmd.Long, "\n"+devpreview.Note) {
+		t.Fatalf("command %q long does not include the developer preview note: %q",
+			cmd.CommandPath(), cmd.Long)
+	}
+
+	if !strings.Contains(help, devpreview.Note) {
+		t.Fatalf("command %q help text does not include the developer preview note: %v",
+			cmd.CommandPath(), help)
+	}
+
+	// For manual inspection
+	fmt.Println(help)
+}
+
+func printOutput(cmd *cobra.Command, args []string) {
+	cmd.Print(output)
+}
+
+func executeCommand(root *cobra.Command, args ...string) (*cobra.Command, string, error) {
+	var buf bytes.Buffer
+
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(args)
+
+	cmd, err := root.ExecuteC()
+
+	return cmd, buf.String(), err
+}

--- a/cmd/odf/dr/dr.go
+++ b/cmd/odf/dr/dr.go
@@ -3,6 +3,8 @@ package dr
 import (
 	"github.com/ramendr/ramenctl/cmd/commands"
 	"github.com/spf13/cobra"
+
+	"github.com/red-hat-storage/odf-cli/cmd/odf/devpreview"
 )
 
 // DrCmd is the dr sub command.
@@ -19,4 +21,6 @@ func init() {
 	// Add a subset of ramenctl commands suitable for "odf dr".
 	DrCmd.AddCommand(commands.InitCmd)
 	DrCmd.AddCommand(commands.TestCmd)
+
+	devpreview.Configure(DrCmd)
 }

--- a/docs/dr.md
+++ b/docs/dr.md
@@ -5,6 +5,11 @@ The dr command supports the following sub-commands:
 * [init](#init)
 * [test](#test)
 
+> [!IMPORTANT]
+> This command is a developer preview, unsupported and not fully tested.
+> Please see the following document for more info on developer preview:
+> https://access.redhat.com/support/offerings/devpreview.
+
 ## init
 
 The init command crates a configuration file required for all other dr commands.


### PR DESCRIPTION
The odf dr command is hidden and all dr commands have a developer preview note.

This is a backport of:
- https://github.com/red-hat-storage/odf-cli/pull/175

4.20 backport: #190

Planned for 4.19.6.