### PR TITLE
dr: update ramenctl to v0.11.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.19.0
 	github.com/pkg/errors v0.9.1
-	github.com/ramendr/ramenctl v0.11.0
+	github.com/ramendr/ramenctl v0.11.1
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d
 	github.com/rook/kubectl-rook-ceph v0.9.4
 	github.com/rook/rook v1.18.1
@@ -155,7 +155,7 @@ require (
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
 	github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 // indirect
-	github.com/ramendr/ramen/e2e v0.0.0-20250722150952-d4c9b950df94 // indirect
+	github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9 // indirect
 	github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2407,10 +2407,10 @@ github.com/prometheus/procfs v0.16.0/go.mod h1:8veyXUu3nGP7oaCxhX6yeaM5u4stL2FeM
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 h1:2hL/5Ofwx/7O2NRA7q3WdL4rHe1yl8k3sHy7GNkCp+A=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5/go.mod h1:vtuEN3pI8SD0WEp5jAPf2Bqi/3CeiuQZkNz6F52NIqo=
-github.com/ramendr/ramen/e2e v0.0.0-20250722150952-d4c9b950df94 h1:ts1Z8oSS0ozaenQqd2wQ3z6y//w29GYVmaHwXzoBrGo=
-github.com/ramendr/ramen/e2e v0.0.0-20250722150952-d4c9b950df94/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
-github.com/ramendr/ramenctl v0.11.0 h1:D7e3VFi5abmfl+WYcyHBpgkZegpNPOx9/4wHAOGOLOY=
-github.com/ramendr/ramenctl v0.11.0/go.mod h1:pIXaTPR5t5fR18GkTN2FmoD2Bpv5aoRaDp1c4bLT0F4=
+github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9 h1:MVV2VLaG5tToXewTqWkQVNm6/W0Yz91W26PNDbaRxmg=
+github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
+github.com/ramendr/ramenctl v0.11.1 h1:v0JcZgKooPyPDSds7E1LhQMXtbYX4+AaaYQlCLTo8fM=
+github.com/ramendr/ramenctl v0.11.1/go.mod h1:lohHdypOtHw9JMiykZvHiHIUDQNIqZNgk6gDXu/nHrQ=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d h1:/AnA3CccDrZZfgaJSKIWMZOznzq2k5W9CXmj4Vyhxik=


### PR DESCRIPTION
This version include recent bug fixes and enhancements since v0.11.0: https://github.com/RamenDR/ramenctl/releases/tag/v0.11.1

Fixes: https://issues.redhat.com/browse/DFBUGS-4001