### PR TITLE
build(deps): update ramenctl to v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.19.0
 	github.com/pkg/errors v0.9.1
-	github.com/ramendr/ramenctl v0.11.1
+	github.com/ramendr/ramenctl v0.12.0
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d
 	github.com/rook/kubectl-rook-ceph v0.9.4
 	github.com/rook/rook v1.18.2
@@ -155,7 +155,7 @@ require (
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
 	github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 // indirect
-	github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9 // indirect
+	github.com/ramendr/ramen/e2e v0.0.0-20250925105626-1e3bf8dbc4d1 // indirect
 	github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1778,8 +1778,15 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/go.sum
+++ b/go.sum
@@ -2404,10 +2404,10 @@ github.com/prometheus/procfs v0.16.0/go.mod h1:8veyXUu3nGP7oaCxhX6yeaM5u4stL2FeM
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 h1:2hL/5Ofwx/7O2NRA7q3WdL4rHe1yl8k3sHy7GNkCp+A=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5/go.mod h1:vtuEN3pI8SD0WEp5jAPf2Bqi/3CeiuQZkNz6F52NIqo=
-github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9 h1:MVV2VLaG5tToXewTqWkQVNm6/W0Yz91W26PNDbaRxmg=
-github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
-github.com/ramendr/ramenctl v0.11.1 h1:v0JcZgKooPyPDSds7E1LhQMXtbYX4+AaaYQlCLTo8fM=
-github.com/ramendr/ramenctl v0.11.1/go.mod h1:lohHdypOtHw9JMiykZvHiHIUDQNIqZNgk6gDXu/nHrQ=
+github.com/ramendr/ramen/e2e v0.0.0-20250925105626-1e3bf8dbc4d1 h1:ltQUo1hPMFUhF/oLJZ/OglRCoJMWZkugYAEzzbg/sU0=
+github.com/ramendr/ramen/e2e v0.0.0-20250925105626-1e3bf8dbc4d1/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
+github.com/ramendr/ramenctl v0.12.0 h1:vO76mIa5HUp+dkcQoDFnxrMEbxqlQbY0y+5dtTtdtMs=
+github.com/ramendr/ramenctl v0.12.0/go.mod h1:bSDn2uqjlGC9r66f+DN9+JOQF19fSZLb6ePSpbRNO+M=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d h1:/AnA3CccDrZZfgaJSKIWMZOznzq2k5W9CXmj4Vyhxik=


### PR DESCRIPTION
This version includes improvements for ODF 4.21 and various fixes and                                                                   
cleanups:
https://github.com/RamenDR/ramenctl/releases/tag/v0.12.0
