### PR TITLE
dr: Remove dev-preview warnings

### DIFF
--- a/cmd/odf/dr/dr.go
+++ b/cmd/odf/dr/dr.go
@@ -3,8 +3,6 @@ package dr
 import (
 	"github.com/ramendr/ramenctl/cmd/commands"
 	"github.com/spf13/cobra"
-
-	"github.com/red-hat-storage/odf-cli/cmd/odf/devpreview"
 )
 
 // DrCmd is the dr sub command.
@@ -23,6 +21,4 @@ func init() {
 	DrCmd.AddCommand(commands.TestCmd)
 	DrCmd.AddCommand(commands.ValidateCmd)
 	DrCmd.AddCommand(commands.GatherCmd)
-
-	devpreview.Configure(DrCmd)
 }


### PR DESCRIPTION
The dr command not dev-preview in ODF 4.22. Remove the warning and include the command in odf --help text.