### PR TITLE
build: remove ob obc crds from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 _output
 _cache
 bin
-pkg/noobaa/crds/

--- a/pkg/noobaa/crds/objectbucket.io_objectbucketclaims_crd.yaml
+++ b/pkg/noobaa/crds/objectbucket.io_objectbucketclaims_crd.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbucketclaims.objectbucket.io
+spec:
+  conversion:
+    strategy: None
+  group: objectbucket.io
+  names:
+    kind: ObjectBucketClaim
+    listKind: ObjectBucketClaimList
+    plural: objectbucketclaims
+    shortNames:
+    - obc
+    - obcs
+    singular: objectbucketclaim
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: StorageClass
+      jsonPath: .spec.storageClassName
+      name: Storage-Class
+      type: string
+    - description: Phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          spec:
+            description: Specification of the desired behavior of the claim.
+            properties:
+              additionalConfig:
+                additionalProperties:
+                  type: string
+                description: AdditionalConfig gives providers a location to set proprietary
+                  config values (tenant, namespace, etc)
+                type: object
+              bucketName:
+                description: BucketName (not recommended) the name of the bucket.
+                  Caution! In-store bucket names may collide across namespaces.  If
+                  you define the name yourself, try to make it as unique as possible.
+                type: string
+              objectBucketName:
+                description: ObjectBucketName is the name of the object bucket resource. 
+                  This is the authoritative determination for binding.
+                type: string
+              generateBucketName:
+                description: GenerateBucketName (recommended) a prefix for a bucket
+                  name to be followed by a hyphen and 5 random characters. Protects
+                  against in-store name collisions.
+                type: string
+              storageClassName:
+                description: StorageClass names the StorageClass object representing
+                  the desired provisioner and parameters
+                type: string
+            required:
+            - storageClassName
+            type: object
+          status:
+            description: Most recently observed status of the claim.
+            properties:
+              phase:
+                description: ObjectBucketClaimStatusPhase is set by the controller
+                  to save the state of the provisioning process
+                enum:
+                - Pending
+                - Bound
+                - Released
+                - Failed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/noobaa/crds/objectbucket.io_objectbuckets_crd.yaml
+++ b/pkg/noobaa/crds/objectbucket.io_objectbuckets_crd.yaml
@@ -1,0 +1,125 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbuckets.objectbucket.io
+spec:
+  conversion:
+    strategy: None
+  group: objectbucket.io
+  names:
+    kind: ObjectBucket
+    listKind: ObjectBucketList
+    plural: objectbuckets
+    shortNames:
+    - ob
+    - obs
+    singular: objectbucket
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: StorageClass
+      jsonPath: .spec.storageClassName
+      name: Storage-Class
+      type: string
+    - description: ClaimNamespace
+      jsonPath: .spec.claimRef.namespace
+      name: Claim-Namespace
+      type: string
+    - description: ClaimName
+      jsonPath: .spec.claimRef.name
+      name: Claim-Name
+      type: string
+    - description: ReclaimPolicy
+      jsonPath: .spec.reclaimPolicy
+      name: Reclaim-Policy
+      type: string
+    - description: Phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          spec:
+            description: Specification of the desired behavior of the bucket.
+            properties:
+              additionalState:
+                additionalProperties:
+                  type: string
+                description: additionalState gives providers a location to set proprietary
+                  config values (tenant, namespace, etc)
+                type: object
+              claimRef:
+                description: ObjectReference to ObjectBucketClaim
+                type: object
+              endpoint:
+                description: Endpoint contains all connection relevant data that an
+                  app may require for accessing the bucket
+                properties:
+                  additionalConfig:
+                    additionalProperties:
+                      type: string
+                    description: AdditionalConfig gives providers a location to set
+                      proprietary config values (tenant, namespace, etc)
+                    type: object
+                  bucketHost:
+                    description: Bucket address hostname
+                    type: string
+                  bucketName:
+                    description: Bucket name
+                    type: string
+                  bucketPort:
+                    description: Bucket address port
+                    type: integer
+                  region:
+                    description: Bucket region
+                    type: string
+                  subRegion:
+                    description: Bucket sub-region
+                    type: string
+                type: object
+              reclaimPolicy:
+                description: Describes a policy for end-of-life maintenance of ObjectBucket.
+                enum:
+                - Delete
+                - Retain
+                - Recycle
+                type: string
+              storageClassName:
+                description: StorageClass names the StorageClass object representing
+                  the desired provisioner and parameters
+                type: string
+            required:
+            - storageClassName
+            type: object
+          status:
+            description: Most recently observed status of the bucket.
+            properties:
+              phase:
+                description: ObjectBucketStatusPhase is set by the controller to save
+                  the state of the provisioning process
+                enum:
+                - Bound
+                - Released
+                - Failed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
downstream build are not connected to network, and due to this build is failing to pull noobaa ob/obc crds at build time to fix this we need to have ob/obc present in the code base.