### PR TITLE
DFBUGS-6400: deps: update ramenctl to v0.19.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ceph/ceph-csi-operator/api v0.0.0-20260330085655-5fad4eb859fb
 	github.com/noobaa/noobaa-operator/v5 v5.21.0
 	github.com/pkg/errors v0.9.1
-	github.com/ramendr/ramenctl v0.18.0
+	github.com/ramendr/ramenctl v0.19.0
 	github.com/red-hat-storage/ocs-client-operator/api v0.0.0-20260331224201-4379cf15edad
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d
 	github.com/rook/kubectl-rook-ceph v0.9.6
@@ -79,7 +79,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.3 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
-	github.com/aymanbagabas/go-udiff v0.4.1 // indirect
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2566,8 +2566,8 @@ github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30 h1:q6ci5ht39oiDf
 github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30/go.mod h1:G3q4wmHUdOVefjCKSacg3McDodLwtfFe84wSrGxQ69w=
 github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780 h1:6TJ2D6N8sfFYWXXTyzkLQg7nBFu0yNYZdGmnRkhcOOU=
 github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780/go.mod h1:BhAPwG+WRu/nJ3Qr9BM+pEMNu6N4QYGftCczD8QWsHk=
-github.com/ramendr/ramenctl v0.18.0 h1:fh9GepH+x2pfl3nNMBpmK+kqajIciHDFBTF8pDqn80g=
-github.com/ramendr/ramenctl v0.18.0/go.mod h1:cqPXruupu0efTOk6gORvxexLvtSz+OA1e0+dWuGOhKA=
+github.com/ramendr/ramenctl v0.19.0 h1:18kz+0Hos0g30jXq024mtxOEcfgiQcHSQcJEnZhGHeE=
+github.com/ramendr/ramenctl v0.19.0/go.mod h1:cqPXruupu0efTOk6gORvxexLvtSz+OA1e0+dWuGOhKA=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/red-hat-storage/ocs-client-operator/api v0.0.0-20260331224201-4379cf15edad h1:+WpGnLYj2/XpiONyCmncIxo6O+/KqCoJOh62dWaVPks=


### PR DESCRIPTION
This version fixes the following bugs:
- https://redhat.atlassian.net/browse/DFBUGS-6399
- https://redhat.atlassian.net/browse/DFBUGS-6400


(cherry picked from commit 0fc2e626c2636ad288a740394dcc286db7eae447)