### PR TITLE
object: add remote-obc with object enable/disable command

### DIFF
--- a/cmd/odf/object/object.go
+++ b/cmd/odf/object/object.go
@@ -20,7 +20,7 @@ var ObjectCmd = &cobra.Command{
 }
 
 var enableCmd = &cobra.Command{
-	Use:       "enable",
+	Use:       fmt.Sprintf("enable %s", remoteOBCArg),
 	Short:     "Install the ObjectBucket and ObjectBucketClaim CRDs",
 	Example:   fmt.Sprintf("odf object enable %s", remoteOBCArg),
 	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
@@ -31,7 +31,7 @@ var enableCmd = &cobra.Command{
 }
 
 var disableCmd = &cobra.Command{
-	Use:       "disable",
+	Use:       fmt.Sprintf("disable %s", remoteOBCArg),
 	Short:     "Remove the ObjectBucket and ObjectBucketClaim CRDs",
 	Example:   fmt.Sprintf("odf object disable %s", remoteOBCArg),
 	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),


### PR DESCRIPTION
remote-obc as a arg is not printed as part of uses when `odf object enable -h -n <ns>` is ran see below output

```
odf object enable -h -n openshift-storage-client
Install the ObjectBucket and ObjectBucketClaim CRDs
Usage:
  odf object enable [flags]
Examples:
odf object enable remote-obc
```

it is only listed in the example section which might not be clear for users.