### PR TITLE
noobaa: use noobaa latest branch 5.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# noobaa-operator git tag for OB/OBC CRDs (keep in sync with EmbeddedNoobaaOperatorVersion in pkg/noobaa/crds.go).
-NOOBAA_OPERATOR_VERSION ?= v5.21.0
+# noobaa-operator git tag or branch for OB/OBC CRDs
+NOOBAA_OPERATOR_VERSION ?= 5.22
 
 build: gen-noobaa-crds
 	find . -type f -name '*.go' -print0 | xargs -0 gofmt -w

--- a/pkg/noobaa/crds.go
+++ b/pkg/noobaa/crds.go
@@ -13,9 +13,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// EmbeddedNoobaaOperatorVersion is the noobaa-operator release version.
-const EmbeddedNoobaaOperatorVersion = "v5.21.0"
-
 //go:embed crds/*.yaml
 var embeddedCRDs embed.FS
 


### PR DESCRIPTION
let's use noobaa 5.22 branch which will be base for odf 4.22 but JFYI 5.22 is not release yet it just the branch name.