### PR TITLE
Update kubectl-rook-ceph package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ The ODF CLI tool provides configuration and troubleshooting commands for OpenShi
   - `start <deployment-name>`
     - `[--alternate-image <alternate-image>]` : (optional) Start a maintenance deployment with an optional alternative ceph container image
   - `stop <deployment-name>`: Stop the maintenance deployment and restore the mon or OSD deployment
-- `odf subvolume`:
-  - `ls`: Display all the subvolumes
-  - `delete <subvolume> <filesystem> <subvolumegroup>`: Deletes the stale subvolumes
+- `odf subvolume` :
+  - `ls [--stale] [--svg <group>]` : List all subvolumes and their state (in-use, stale, stale-with-snapshot).
+  - `delete <filesystem> <subvolume> [subvolumegroup]` : Delete a stale subvolume and its OMAP metadata.
+
+- `odf cephfs-snap` :
+  - `ls [--orphaned] [--filesystem <fs>] [--svg <group>]` : List all snapshots and their state (bound, orphaned).
+  - `delete <subvolume> <snapshot> [--svg <group>]` : Delete an orphaned snapshot and its OMAP metadata.
 - `odf operator`:
   - `rook`:
     - `set`: Set the property in the rook-ceph-operator-config configmap.
@@ -69,6 +73,8 @@ Visit docs below for complete details about each command and their flags uses.
 - [dr](docs/dr.md)
 - [noobaa](docs/noobaa.md)
 - [object](docs/object.md)
+- [subvolume](docs/subvolume.md)
+- [cephfs-snap](docs/cephfs-snap.md)
 
 ### Root args
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ramendr/ramenctl v0.19.0
 	github.com/red-hat-storage/ocs-client-operator/api v0.0.0-20260331224201-4379cf15edad
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d
-	github.com/rook/kubectl-rook-ceph v0.9.6
+	github.com/rook/kubectl-rook-ceph v0.9.7-0.20260429175457-6245c7127df2
 	github.com/rook/rook v1.19.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -2592,8 +2592,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rook/kubectl-rook-ceph v0.9.6 h1:jCEtbGzLPRdAtl5L1E7mJCt9ff+26ciucsmJ4EfJ7WE=
-github.com/rook/kubectl-rook-ceph v0.9.6/go.mod h1:s9G3cH58EwhZsQoQ8OsZ5+tEYxRtZiA8COU6RlziVQU=
+github.com/rook/kubectl-rook-ceph v0.9.7-0.20260429175457-6245c7127df2 h1:r03vpGwDe8KP9UP8/QWU8TCGn9Rnq/UVKe5kQJA/3eY=
+github.com/rook/kubectl-rook-ceph v0.9.7-0.20260429175457-6245c7127df2/go.mod h1:qMDQ32PAbMLXqKY5U6ip8DYR3NleHGn4HfVDxdY8a+c=
 github.com/rook/rook v1.19.4 h1:NrgH7qR97bvZYwhM/rQOF8/Viu/8v7kmvtlMzitBUR8=
 github.com/rook/rook v1.19.4/go.mod h1:+5loH3XQTnQZKd1qijtZQT8WxCjkDosoNmZhYCoQeOY=
 github.com/rook/rook/pkg/apis v0.0.0-20260210155143-d82f6dee9790 h1:ryr6K9tDwjUd4/+runDOSKAi0Ux0X2c/HKBEVYv0GgE=


### PR DESCRIPTION
This PR:
- Updates kubectl-rook-ceph package to reflect the recent changes(https://github.com/rook/kubectl-rook-ceph/pull/445)
- Adds subvolume and snapshot commands to the README.md file. 