### PR TITLE
DFBUGS-6712: deps: update ramenctl to v0.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ceph/ceph-csi-operator/api v0.0.0-20260330085655-5fad4eb859fb
 	github.com/noobaa/noobaa-operator/v5 v5.21.0
 	github.com/pkg/errors v0.9.1
-	github.com/ramendr/ramenctl v0.20.0
+	github.com/ramendr/ramenctl v0.21.0
 	github.com/red-hat-storage/ocs-client-operator/api v0.0.0-20260331224201-4379cf15edad
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d
 	github.com/rook/kubectl-rook-ceph v0.9.7-0.20260429175457-6245c7127df2

--- a/go.sum
+++ b/go.sum
@@ -2567,8 +2567,8 @@ github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30 h1:q6ci5ht39oiDf
 github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30/go.mod h1:G3q4wmHUdOVefjCKSacg3McDodLwtfFe84wSrGxQ69w=
 github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780 h1:6TJ2D6N8sfFYWXXTyzkLQg7nBFu0yNYZdGmnRkhcOOU=
 github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780/go.mod h1:BhAPwG+WRu/nJ3Qr9BM+pEMNu6N4QYGftCczD8QWsHk=
-github.com/ramendr/ramenctl v0.20.0 h1:1afbtezMFGoQn4HnYsdVaH84cO8nckcNuMx5zzSES7k=
-github.com/ramendr/ramenctl v0.20.0/go.mod h1:/mRXOvbpZ3NMQwvWazQW7y7VwVHjQI15822g57i2fGE=
+github.com/ramendr/ramenctl v0.21.0 h1:LAyzH5UUGMlpYOO7AZMuOZMedyCznCuMP0hRfkOdVOQ=
+github.com/ramendr/ramenctl v0.21.0/go.mod h1:/mRXOvbpZ3NMQwvWazQW7y7VwVHjQI15822g57i2fGE=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/red-hat-storage/ocs-client-operator/api v0.0.0-20260331224201-4379cf15edad h1:+WpGnLYj2/XpiONyCmncIxo6O+/KqCoJOh62dWaVPks=


### PR DESCRIPTION
This version fixes the following bugs:
- https://redhat.atlassian.net/browse/DFBUGS-6712

(cherry picked from commit 5b64037719c732977f94661ebdf744450e615921)