### PR TITLE
DFBUGS-6822: deps: update ramenctl to v0.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ceph/ceph-csi-operator/api v0.0.0-20260330085655-5fad4eb859fb
 	github.com/noobaa/noobaa-operator/v5 v5.21.0
 	github.com/pkg/errors v0.9.1
-	github.com/ramendr/ramenctl v0.21.0
+	github.com/ramendr/ramenctl v0.22.0
 	github.com/red-hat-storage/ocs-client-operator/api v0.0.0-20260331224201-4379cf15edad
 	github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240701091545-dfffbde82a9d
 	github.com/rook/kubectl-rook-ceph v0.9.7-0.20260429175457-6245c7127df2
@@ -185,7 +185,7 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/nirs/kubectl-gather v0.12.0 // indirect
+	github.com/nirs/kubectl-gather v0.13.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/openshift/api v0.0.0-20251120040117-916c7003ed78 // indirect
 	github.com/openshift/cloud-credential-operator v0.0.0-20231004191224-abdf0627a0cf // indirect

--- a/go.sum
+++ b/go.sum
@@ -2376,8 +2376,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nirs/kubectl-gather v0.12.0 h1:jRCbo8n3uTHobBz5R4B+KdPYD+XP1JRNccjTTyzNG/c=
-github.com/nirs/kubectl-gather v0.12.0/go.mod h1:m1P+K5iDF2t2tLDigXHOeTzfvIVpXHLddxLbH+dd2+E=
+github.com/nirs/kubectl-gather v0.13.0 h1:Gldom4SSb74CELtBHDYTA5SWAOm6w0/IJZ+z0SitFPg=
+github.com/nirs/kubectl-gather v0.13.0/go.mod h1:FbyZguoDTZFY9OAib74tBFw2jlOzlzh1m7JjgEwQ2Rs=
 github.com/noobaa/noobaa-operator/v5 v5.21.0 h1:J5Yf6r3hz3zLv1R/ElwgQgfwf6bzf21H5BCzQqzCJHk=
 github.com/noobaa/noobaa-operator/v5 v5.21.0/go.mod h1:QXorpVxt6MqAfrhsKeCyjqEJx3pZd+wfFlGTrCh090A=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -2567,8 +2567,8 @@ github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30 h1:q6ci5ht39oiDf
 github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30/go.mod h1:G3q4wmHUdOVefjCKSacg3McDodLwtfFe84wSrGxQ69w=
 github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780 h1:6TJ2D6N8sfFYWXXTyzkLQg7nBFu0yNYZdGmnRkhcOOU=
 github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780/go.mod h1:BhAPwG+WRu/nJ3Qr9BM+pEMNu6N4QYGftCczD8QWsHk=
-github.com/ramendr/ramenctl v0.21.0 h1:LAyzH5UUGMlpYOO7AZMuOZMedyCznCuMP0hRfkOdVOQ=
-github.com/ramendr/ramenctl v0.21.0/go.mod h1:/mRXOvbpZ3NMQwvWazQW7y7VwVHjQI15822g57i2fGE=
+github.com/ramendr/ramenctl v0.22.0 h1:PH3vTSrdeNexxrbGRvSfJ8R5EDoxHX5rQUk+FQfUNLA=
+github.com/ramendr/ramenctl v0.22.0/go.mod h1:xgEHl4BlkTtdD5YR0SqEA7LJhe3Re/Eb2TYo+KCAypE=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/red-hat-storage/ocs-client-operator/api v0.0.0-20260331224201-4379cf15edad h1:+WpGnLYj2/XpiONyCmncIxo6O+/KqCoJOh62dWaVPks=


### PR DESCRIPTION
This version fixes the following issues:
- https://redhat.atlassian.net/browse/DFBUGS-6822
- https://redhat.atlassian.net/browse/DFBUGS-6882
- https://redhat.atlassian.net/browse/DFBUGS-6884


(cherry picked from commit ef529cbb79e17f90d8df3124eff7676b66ae266d)