### PR TITLE
build: downgrade go version 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-cli
 
-go 1.25.11
+go 1.25.9
 
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.0.0-20260128131222-4e19231ff259


### PR DESCRIPTION
d/s build support go version till 1.25.9 so
downgrading the go version from v1.25.11 to 1.25.9