### PR TITLE
[release-4.16] Bump go (stdlib) from 1.24.0 to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-cli
 
-go 1.24.0
+go 1.24.2
 
 require (
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.0` → `1.24.2` (in `go.mod`)
