### PR TITLE
[main] Bump go (stdlib) from 1.25.5 to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/odf-cli
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/ceph/ceph-csi-operator/api v0.0.0-20260330085655-5fad4eb859fb


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.25.5` → `1.25.6` (in `go.mod`)
